### PR TITLE
OCSADV-253: End-to-end implementation of ITC service for GMOS imaging.

### DIFF
--- a/app/spdb/build.sbt
+++ b/app/spdb/build.sbt
@@ -99,6 +99,7 @@ def common(version: Version) = AppConfig(
     BundleSpec("edu.gemini.ags.servlet",                 version),
     BundleSpec("edu.gemini.dataman.app",                 version),
     BundleSpec("edu.gemini.horizons.server",             version),
+    BundleSpec("edu.gemini.itc",                         version),
     BundleSpec("edu.gemini.lchquery.servlet",            version),
     BundleSpec("edu.gemini.obslog",                      version),
     BundleSpec("edu.gemini.oodb.auth.servlet",           version),

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import OcsKeys._
 
 name := "ocs"
 
-ocsVersion in ThisBuild := OcsVersion("2015B", true, 1, 1, 1)
+ocsVersion in ThisBuild := OcsVersion("2015B", true, 1, 1, 2)
 
 pitVersion in ThisBuild := OcsVersion("2015B", false, 2, 1, 0)
 

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import OcsKeys._
 
 name := "ocs"
 
-ocsVersion in ThisBuild := OcsVersion("2015B", true, 1, 1, 2)
+ocsVersion in ThisBuild := OcsVersion("2015B", true, 1, 1, 1)
 
 pitVersion in ThisBuild := OcsVersion("2015B", false, 2, 1, 0)
 

--- a/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/impl/VignettingTest.scala
+++ b/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/impl/VignettingTest.scala
@@ -22,6 +22,7 @@ import org.junit.Assert._
 import org.junit.{Ignore, Test}
 
 import scala.collection.JavaConverters._
+import scala.util.Random
 
 /**
  * Right now, we only test for GMOS. In the future, this will be expanded to include other guide probes.
@@ -53,6 +54,17 @@ class VignettingTest {
   val GS9  = siderealTarget("GS9",  "00:00:12.240 -00:02:55.10", 16.0)
   val GS10 = siderealTarget("GS10", "00:00:10.200 -00:01:35.20", 15.5)
   val All = List(GS1, GS2, GS3, GS4, GS5, GS6, GS7, GS8, GS9, GS10)
+
+  // Specifically non-vignetting guide stars for base position (0,0) to test that brightness is correctly chosen.
+  val NVGS1 = siderealTarget("NGS1", "23:59:57.620  00:03:10.40", 11.0)
+  val NVGS2 = siderealTarget("NGS2", "23:59:48.213  00:02:50.00",  9.0)
+  val NVGS3 = siderealTarget("NGS3", "23:59:47.420  00:01:26.70", 10.0)
+  val NVGS4 = siderealTarget("NGS4", "23:59:47.420  00:00:34.00", 12.0)
+  val NVGS5 = siderealTarget("NGS5", "23:59:47.533 -00:00:11.90", 15.5)
+  val NVGS6 = siderealTarget("NGS6", "23:59:53.087  00:03:17.20", 15.4)
+  val NVGS7 = siderealTarget("NGS7", "23:59:47.873  00:02:14.30", 16.0)
+  val NVGS8 = siderealTarget("NGS8", "23:59:59.320  00:03:15.50", 16.5)
+  val AllNV = List(NVGS1, NVGS2, NVGS3, NVGS4, NVGS5, NVGS6, NVGS7, NVGS8)
 
   // Load the magnitude table and create the base position.
   val mt   = ProbeLimitsTable.loadOrThrow()
@@ -106,7 +118,7 @@ class VignettingTest {
           assertTrue(selectionOpt.isEmpty)
       }
     }
-    nextCandidate(candidates, expected)
+    nextCandidate(Random.shuffle(candidates), expected)
   }
 
   @Test def testSideLookingBasePosAngle0() = {
@@ -140,19 +152,25 @@ class VignettingTest {
   }
 
   @Test def testSideLookingOneOffsetPosAngle0() = {
-    val expected   = List(GS2, GS6)
+    val expected = List(GS2, GS6)
     executeTest(GMOSSouthSideLookingWithOI, 0.0, List(Offset(Angle.fromArcsecs(50.0), Angle.fromArcsecs(50.0))), All, expected)
   }
 
   @Test def testSideLookingOneOffset2PosAngle0() = {
     // The vignetting exclusively on the offset would result in GS6 and then GS7, but the vignetting averaged across
     // the base position and the offset would result in GS7 and then GS6.
-    val expected   = List(GS7, GS6)
+    val expected = List(GS7, GS6)
     executeTest(GMOSSouthSideLookingWithOI, 0.0, List(Offset(Angle.fromArcsecs(200.0), Angle.fromArcsecs(50.0))), All, expected)
   }
 
-  @Test def testSideLookingOneNegOffset2PosAngle0() = {
-    val expected   = List(GS5, GS3, GS2)
+  // Negative offsets currently do not work.
+  @Ignore @Test def testSideLookingOneNegOffset2PosAngle0() = {
+    val expected = List(GS5, GS3, GS2)
     executeTest(GMOSSouthSideLookingWithOI, 0.0, List(Offset(Angle.fromArcsecs(-50.0), Angle.fromArcsecs(-50.0))), All, expected)
+  }
+
+  @Test def testAllNoVignetting() = {
+    val expected = List(NVGS2, NVGS3, NVGS1, NVGS4, NVGS6, NVGS5, NVGS7)
+    executeTest(GMOSSouthSideLookingWithOI, 0.0, Nil, AllNV, expected)
   }
 }

--- a/bundle/edu.gemini.itc.shared/build.sbt
+++ b/bundle/edu.gemini.itc.shared/build.sbt
@@ -21,7 +21,8 @@ OsgiKeys.bundleActivator := Some("edu.gemini.itc.shared.osgi.Activator")
 OsgiKeys.bundleSymbolicName := name.value
 
 OsgiKeys.exportPackage := Seq(
-  "edu.gemini.itc.service"
+  "edu.gemini.itc.service",
+  "edu.gemini.itc.shared"
 )
 
 OsgiKeys.importPackage := Seq(

--- a/bundle/edu.gemini.itc.shared/src/main/Java/edu/gemini/itc/shared/BrightnessUnit.java
+++ b/bundle/edu.gemini.itc.shared/src/main/Java/edu/gemini/itc/shared/BrightnessUnit.java
@@ -1,0 +1,25 @@
+package edu.gemini.itc.shared;
+
+import edu.gemini.spModel.type.DisplayableSpType;
+
+public enum BrightnessUnit implements DisplayableSpType {
+    // TODO: The "displayable" units are pretty ugly, but we have to keep them for
+    // TODO: now in order to be backwards compatible for regression testing.
+    MAG                 ("mag"),
+    ABMAG               ("ABmag"),
+    JY                  ("Jy"),
+    WATTS               ("watts_fd_wavelength"),
+    ERGS_WAVELENGTH     ("ergs_fd_wavelength"),
+    ERGS_FREQUENCY      ("ergs_fd_frequency"),
+    // -- TODO: same in blue but per area, can we unify those two sets of values?
+    MAG_PSA             ("mag_per_sq_arcsec"),
+    ABMAG_PSA           ("ABmag_per_sq_arcsec"),
+    JY_PSA              ("jy_per_sq_arcsec"),
+    WATTS_PSA           ("watts_fd_wavelength_per_sq_arcsec"),
+    ERGS_WAVELENGTH_PSA ("ergs_fd_wavelength_per_sq_arcsec"),
+    ERGS_FREQUENCY_PSA  ("ergs_fd_frequency_per_sq_arcsec")
+    ;
+    private final String displayValue;
+    private BrightnessUnit(final String displayName) { this.displayValue = displayName; }
+    public String displayValue() {return displayValue;}
+}

--- a/bundle/edu.gemini.itc.shared/src/main/Java/edu/gemini/itc/shared/ObservationDetails.java
+++ b/bundle/edu.gemini.itc.shared/src/main/Java/edu/gemini/itc/shared/ObservationDetails.java
@@ -1,9 +1,13 @@
-package edu.gemini.itc.service;
+package edu.gemini.itc.shared;
+
+import edu.gemini.itc.shared.*;
+
+import java.io.Serializable;
 
 /**
  * Container for observation detail parameters.
  */
-public final class ObservationDetails {
+public final class ObservationDetails implements Serializable {
 
     private final CalculationMethod calculationMethod;
     private final AnalysisMethod analysisMethod;

--- a/bundle/edu.gemini.itc.shared/src/main/Java/edu/gemini/itc/shared/ObservingConditions.java
+++ b/bundle/edu.gemini.itc.shared/src/main/Java/edu/gemini/itc/shared/ObservingConditions.java
@@ -1,14 +1,16 @@
-package edu.gemini.itc.service;
+package edu.gemini.itc.shared;
 
 import edu.gemini.spModel.gemini.obscomp.SPSiteQuality.CloudCover;
 import edu.gemini.spModel.gemini.obscomp.SPSiteQuality.ImageQuality;
 import edu.gemini.spModel.gemini.obscomp.SPSiteQuality.SkyBackground;
 import edu.gemini.spModel.gemini.obscomp.SPSiteQuality.WaterVapor;
 
+import java.io.Serializable;
+
 /**
  * Container for observing condition parameters.
  */
-public final class ObservingConditions {
+public final class ObservingConditions implements Serializable {
 
     private final ImageQuality  iq;
     private final CloudCover    cc;

--- a/bundle/edu.gemini.itc.shared/src/main/Java/edu/gemini/itc/shared/PlottingDetails.java
+++ b/bundle/edu.gemini.itc.shared/src/main/Java/edu/gemini/itc/shared/PlottingDetails.java
@@ -1,9 +1,11 @@
-package edu.gemini.itc.service;
+package edu.gemini.itc.shared;
+
+import java.io.Serializable;
 
 /**
  * Container for plotting detail parameters.
  */
-public final class PlottingDetails {
+public final class PlottingDetails implements Serializable {
 
     public static enum PlotLimits {
         AUTO,

--- a/bundle/edu.gemini.itc.shared/src/main/Java/edu/gemini/itc/shared/SourceDefinition.java
+++ b/bundle/edu.gemini.itc.shared/src/main/Java/edu/gemini/itc/shared/SourceDefinition.java
@@ -1,33 +1,11 @@
-package edu.gemini.itc.service;
+package edu.gemini.itc.shared;
 
-import edu.gemini.spModel.type.DisplayableSpType;
+import java.io.Serializable;
 
 /**
  * Container for source definition parameters.
  */
-public final class SourceDefinition {
-
-    public static enum BrightnessUnit implements DisplayableSpType {
-        // TODO: The "displayable" units are pretty ugly, but we have to keep them for
-        // TODO: now in order to be backwards compatible for regression testing.
-        MAG                 ("mag"),
-        ABMAG               ("ABmag"),
-        JY                  ("Jy"),
-        WATTS               ("watts_fd_wavelength"),
-        ERGS_WAVELENGTH     ("ergs_fd_wavelength"),
-        ERGS_FREQUENCY      ("ergs_fd_frequency"),
-        // -- TODO: same in blue but per area, can we unify those two sets of values?
-        MAG_PSA             ("mag_per_sq_arcsec"),
-        ABMAG_PSA           ("ABmag_per_sq_arcsec"),
-        JY_PSA              ("jy_per_sq_arcsec"),
-        WATTS_PSA           ("watts_fd_wavelength_per_sq_arcsec"),
-        ERGS_WAVELENGTH_PSA ("ergs_fd_wavelength_per_sq_arcsec"),
-        ERGS_FREQUENCY_PSA  ("ergs_fd_frequency_per_sq_arcsec")
-        ;
-        private final String displayValue;
-        private BrightnessUnit(final String displayName) { this.displayValue = displayName; }
-        public String displayValue() {return displayValue;}
-    }
+public final class SourceDefinition implements Serializable {
 
     public static enum Recession {
         REDSHIFT,

--- a/bundle/edu.gemini.itc.shared/src/main/Java/edu/gemini/itc/shared/TelescopeDetails.java
+++ b/bundle/edu.gemini.itc.shared/src/main/Java/edu/gemini/itc/shared/TelescopeDetails.java
@@ -1,12 +1,14 @@
-package edu.gemini.itc.service;
+package edu.gemini.itc.shared;
 
 import edu.gemini.spModel.telescope.IssPort;
 import edu.gemini.spModel.type.DisplayableSpType;
 
+import java.io.Serializable;
+
 /**
  * Container for telescope parameters.
  */
-public final class TelescopeDetails {
+public final class TelescopeDetails implements Serializable {
 
     public static enum Coating implements DisplayableSpType {
         ALUMINIUM("aluminium"),

--- a/bundle/edu.gemini.itc.shared/src/main/Java/edu/gemini/itc/shared/WavebandDefinition.java
+++ b/bundle/edu.gemini.itc.shared/src/main/Java/edu/gemini/itc/shared/WavebandDefinition.java
@@ -1,4 +1,4 @@
-package edu.gemini.itc.service;
+package edu.gemini.itc.shared;
 
 /**
  * This class represents the definition of standard "wavebands",

--- a/bundle/edu.gemini.itc.shared/src/main/scala/edu/gemini/itc/shared/InstrumentDetails.scala
+++ b/bundle/edu.gemini.itc.shared/src/main/scala/edu/gemini/itc/shared/InstrumentDetails.scala
@@ -1,4 +1,4 @@
-package edu.gemini.itc.service
+package edu.gemini.itc.shared
 
 import edu.gemini.spModel.core.Site
 import edu.gemini.spModel.gemini.gmos.GmosCommonType.{DetectorManufacturer, FPUnit, Disperser, Filter}

--- a/bundle/edu.gemini.itc.shared/src/main/scala/edu/gemini/itc/shared/ItcService.scala
+++ b/bundle/edu.gemini.itc.shared/src/main/scala/edu/gemini/itc/shared/ItcService.scala
@@ -1,5 +1,11 @@
-package edu.gemini.itc.service
+package edu.gemini.itc.shared
 
+import edu.gemini.spModel.core.Peer
+import edu.gemini.util.security.auth.keychain.KeyChain
+import edu.gemini.util.trpc.client.TrpcClient
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
 import scalaz.{Failure, Success, Validation}
 
 /**
@@ -16,7 +22,7 @@ final case class ItcSpectroscopyResult(/*TODO*/) extends ItcCalcResult
  * return one result (either because they don't have more than one CCD or because all different CCDs are assumed to
  * have the same characteristics).
  */
-sealed trait ItcResult {
+sealed trait ItcResult extends Serializable {
   /** Returns the results for all CCDs. */
   def ccds: Array[ItcCalcResult]
 
@@ -26,7 +32,7 @@ sealed trait ItcResult {
 
 object ItcResult {
 
-  import ItcService._
+  import edu.gemini.itc.shared.ItcService._
 
   /** Creates an ITC result in case of an error. */
   def forException(e: Throwable): Result = Failure(List(e.getMessage))
@@ -43,7 +49,7 @@ object ItcResult {
  */
 trait ItcService {
 
-  import ItcService._
+  import edu.gemini.itc.shared.ItcService._
 
   def calculate(source: SourceDefinition, obs: ObservationDetails, cond: ObservingConditions, tele: TelescopeDetails, ins: InstrumentDetails): Result
 
@@ -52,5 +58,11 @@ trait ItcService {
 object ItcService {
 
   type Result = Validation[List[String], ItcResult]
+
+  /** Performs an ITC call on the given host. */
+  def calculate(kc: KeyChain, peer: Peer, source: SourceDefinition, obs: ObservationDetails, cond: ObservingConditions, tele: TelescopeDetails, ins: InstrumentDetails): Future[Result] =
+    TrpcClient(peer).withKeyChain(kc) future { r =>
+      r[ItcService].calculate(source, obs, cond, tele, ins)
+    }
 
 }

--- a/bundle/edu.gemini.itc.shared/src/main/scala/edu/gemini/itc/shared/Parameters.scala
+++ b/bundle/edu.gemini.itc.shared/src/main/scala/edu/gemini/itc/shared/Parameters.scala
@@ -1,6 +1,4 @@
-package edu.gemini.itc.service
-
-import edu.gemini.itc.service.SourceDefinition.BrightnessUnit
+package edu.gemini.itc.shared
 
 // ==== Source spatial profile
 

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/acqcam/AcqCamRecipe.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/acqcam/AcqCamRecipe.java
@@ -1,10 +1,10 @@
 package edu.gemini.itc.acqcam;
 
 import edu.gemini.itc.operation.*;
-import edu.gemini.itc.service.ObservationDetails;
-import edu.gemini.itc.service.ObservingConditions;
-import edu.gemini.itc.service.SourceDefinition;
-import edu.gemini.itc.service.TelescopeDetails;
+import edu.gemini.itc.shared.ObservationDetails;
+import edu.gemini.itc.shared.ObservingConditions;
+import edu.gemini.itc.shared.SourceDefinition;
+import edu.gemini.itc.shared.TelescopeDetails;
 import edu.gemini.itc.shared.*;
 import edu.gemini.itc.web.HtmlPrinter;
 import edu.gemini.itc.web.ITCRequest;

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/acqcam/AcquisitionCamParameters.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/acqcam/AcquisitionCamParameters.java
@@ -1,6 +1,6 @@
 package edu.gemini.itc.acqcam;
 
-import edu.gemini.itc.service.InstrumentDetails;
+import edu.gemini.itc.shared.InstrumentDetails;
 import edu.gemini.itc.shared.ITCMultiPartParser;
 import edu.gemini.itc.shared.ITCParameters;
 

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/flamingos2/Flamingos2Parameters.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/flamingos2/Flamingos2Parameters.java
@@ -1,6 +1,6 @@
 package edu.gemini.itc.flamingos2;
 
-import edu.gemini.itc.service.InstrumentDetails;
+import edu.gemini.itc.shared.InstrumentDetails;
 import edu.gemini.itc.shared.ITCMultiPartParser;
 import edu.gemini.itc.shared.ITCParameters;
 

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/flamingos2/Flamingos2Recipe.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/flamingos2/Flamingos2Recipe.java
@@ -1,7 +1,6 @@
 package edu.gemini.itc.flamingos2;
 
 import edu.gemini.itc.operation.*;
-import edu.gemini.itc.service.*;
 import edu.gemini.itc.shared.*;
 import edu.gemini.itc.web.HtmlPrinter;
 import edu.gemini.itc.web.ITCRequest;

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gems/Gems.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gems/Gems.java
@@ -1,6 +1,6 @@
 package edu.gemini.itc.gems;
 
-import edu.gemini.itc.service.SourceDefinition;
+import edu.gemini.itc.shared.SourceDefinition;
 import edu.gemini.itc.shared.AOSystem;
 import edu.gemini.itc.shared.FormatStringWriter;
 import edu.gemini.itc.shared.SampledSpectrumVisitor;

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gmos/Gmos.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gmos/Gmos.java
@@ -1,10 +1,10 @@
 package edu.gemini.itc.gmos;
 
 import edu.gemini.itc.operation.DetectorsTransmissionVisitor;
-import edu.gemini.itc.service.GmosParameters;
-import edu.gemini.itc.service.IfuRadial;
-import edu.gemini.itc.service.IfuSingle;
-import edu.gemini.itc.service.ObservationDetails;
+import edu.gemini.itc.shared.GmosParameters;
+import edu.gemini.itc.shared.IfuRadial;
+import edu.gemini.itc.shared.IfuSingle;
+import edu.gemini.itc.shared.ObservationDetails;
 import edu.gemini.itc.shared.*;
 import edu.gemini.spModel.gemini.gmos.GmosCommonType;
 import edu.gemini.spModel.gemini.gmos.GmosNorthType;

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gmos/GmosNorth.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gmos/GmosNorth.java
@@ -1,7 +1,7 @@
 package edu.gemini.itc.gmos;
 
-import edu.gemini.itc.service.GmosParameters;
-import edu.gemini.itc.service.ObservationDetails;
+import edu.gemini.itc.shared.GmosParameters;
+import edu.gemini.itc.shared.ObservationDetails;
 
 /**
  * Gmos specification class

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gmos/GmosRecipe.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gmos/GmosRecipe.java
@@ -1,7 +1,6 @@
 package edu.gemini.itc.gmos;
 
 import edu.gemini.itc.operation.*;
-import edu.gemini.itc.service.*;
 import edu.gemini.itc.shared.*;
 import edu.gemini.itc.web.HtmlPrinter;
 import edu.gemini.itc.web.ITCRequest;
@@ -318,7 +317,7 @@ public final class GmosRecipe extends RecipeBase {
 
     // Calculation results
     // TEMPORARY, these will probably turn into Scala case classes
-    interface GmosResult {}
+    public interface GmosResult {}
     public static final class GmosImagingResult implements GmosResult {
         public final SourceFraction SFcalc;
         public final double peak_pixel_count;

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gmos/GmosSouth.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gmos/GmosSouth.java
@@ -1,7 +1,7 @@
 package edu.gemini.itc.gmos;
 
-import edu.gemini.itc.service.GmosParameters;
-import edu.gemini.itc.service.ObservationDetails;
+import edu.gemini.itc.shared.GmosParameters;
+import edu.gemini.itc.shared.ObservationDetails;
 
 /**
  * Gmos specification class

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gnirs/Gnirs.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gnirs/Gnirs.java
@@ -1,6 +1,6 @@
 package edu.gemini.itc.gnirs;
 
-import edu.gemini.itc.service.CalculationMethod;
+import edu.gemini.itc.shared.CalculationMethod;
 import edu.gemini.itc.shared.*;
 
 

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gnirs/GnirsNorth.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gnirs/GnirsNorth.java
@@ -1,7 +1,7 @@
 package edu.gemini.itc.gnirs;
 
 import edu.gemini.itc.operation.DetectorsTransmissionVisitor;
-import edu.gemini.itc.service.ObservationDetails;
+import edu.gemini.itc.shared.ObservationDetails;
 import edu.gemini.itc.shared.*;
 
 public final class GnirsNorth extends Gnirs {

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gnirs/GnirsParameters.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gnirs/GnirsParameters.java
@@ -1,6 +1,6 @@
 package edu.gemini.itc.gnirs;
 
-import edu.gemini.itc.service.InstrumentDetails;
+import edu.gemini.itc.shared.InstrumentDetails;
 import edu.gemini.itc.shared.ITCMultiPartParser;
 import edu.gemini.itc.shared.ITCParameters;
 

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gnirs/GnirsRecipe.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gnirs/GnirsRecipe.java
@@ -1,7 +1,6 @@
 package edu.gemini.itc.gnirs;
 
 import edu.gemini.itc.operation.*;
-import edu.gemini.itc.service.*;
 import edu.gemini.itc.shared.*;
 import edu.gemini.itc.web.HtmlPrinter;
 import edu.gemini.itc.web.ITCRequest;

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gsaoi/Gsaoi.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gsaoi/Gsaoi.java
@@ -1,6 +1,6 @@
 package edu.gemini.itc.gsaoi;
 
-import edu.gemini.itc.service.ObservationDetails;
+import edu.gemini.itc.shared.ObservationDetails;
 import edu.gemini.itc.shared.*;
 
 /**

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gsaoi/GsaoiParameters.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gsaoi/GsaoiParameters.java
@@ -1,6 +1,6 @@
 package edu.gemini.itc.gsaoi;
 
-import edu.gemini.itc.service.InstrumentDetails;
+import edu.gemini.itc.shared.InstrumentDetails;
 import edu.gemini.itc.shared.ITCMultiPartParser;
 import edu.gemini.itc.shared.ITCParameters;
 

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gsaoi/GsaoiRecipe.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gsaoi/GsaoiRecipe.java
@@ -2,10 +2,10 @@ package edu.gemini.itc.gsaoi;
 
 import edu.gemini.itc.gems.*;
 import edu.gemini.itc.operation.*;
-import edu.gemini.itc.service.ObservationDetails;
-import edu.gemini.itc.service.ObservingConditions;
-import edu.gemini.itc.service.SourceDefinition;
-import edu.gemini.itc.service.TelescopeDetails;
+import edu.gemini.itc.shared.ObservationDetails;
+import edu.gemini.itc.shared.ObservingConditions;
+import edu.gemini.itc.shared.SourceDefinition;
+import edu.gemini.itc.shared.TelescopeDetails;
 import edu.gemini.itc.shared.*;
 import edu.gemini.itc.web.HtmlPrinter;
 import edu.gemini.itc.web.ITCRequest;

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/michelle/Michelle.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/michelle/Michelle.java
@@ -1,8 +1,8 @@
 package edu.gemini.itc.michelle;
 
 import edu.gemini.itc.operation.DetectorsTransmissionVisitor;
-import edu.gemini.itc.service.ObservationDetails;
-import edu.gemini.itc.service.CalculationMethod;
+import edu.gemini.itc.shared.ObservationDetails;
+import edu.gemini.itc.shared.CalculationMethod;
 import edu.gemini.itc.shared.*;
 
 /**

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/michelle/MichelleParameters.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/michelle/MichelleParameters.java
@@ -1,6 +1,6 @@
 package edu.gemini.itc.michelle;
 
-import edu.gemini.itc.service.InstrumentDetails;
+import edu.gemini.itc.shared.InstrumentDetails;
 import edu.gemini.itc.shared.ITCMultiPartParser;
 import edu.gemini.itc.shared.ITCParameters;
 

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/michelle/MichelleRecipe.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/michelle/MichelleRecipe.java
@@ -1,7 +1,6 @@
 package edu.gemini.itc.michelle;
 
 import edu.gemini.itc.operation.*;
-import edu.gemini.itc.service.*;
 import edu.gemini.itc.shared.*;
 import edu.gemini.itc.web.HtmlPrinter;
 import edu.gemini.itc.web.ITCRequest;

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/nifs/Nifs.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/nifs/Nifs.java
@@ -1,6 +1,6 @@
 package edu.gemini.itc.nifs;
 
-import edu.gemini.itc.service.CalculationMethod;
+import edu.gemini.itc.shared.CalculationMethod;
 import edu.gemini.itc.shared.*;
 
 /**

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/nifs/NifsNorth.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/nifs/NifsNorth.java
@@ -1,7 +1,7 @@
 package edu.gemini.itc.nifs;
 
 import edu.gemini.itc.operation.DetectorsTransmissionVisitor;
-import edu.gemini.itc.service.ObservationDetails;
+import edu.gemini.itc.shared.ObservationDetails;
 import edu.gemini.itc.shared.*;
 
 /**

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/nifs/NifsParameters.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/nifs/NifsParameters.java
@@ -1,6 +1,6 @@
 package edu.gemini.itc.nifs;
 
-import edu.gemini.itc.service.InstrumentDetails;
+import edu.gemini.itc.shared.InstrumentDetails;
 import edu.gemini.itc.shared.ITCMultiPartParser;
 import edu.gemini.itc.shared.ITCParameters;
 

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/nifs/NifsRecipe.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/nifs/NifsRecipe.java
@@ -4,7 +4,6 @@ import edu.gemini.itc.altair.*;
 import edu.gemini.itc.operation.ImageQualityCalculatable;
 import edu.gemini.itc.operation.ImageQualityCalculationFactory;
 import edu.gemini.itc.operation.SpecS2NLargeSlitVisitor;
-import edu.gemini.itc.service.*;
 import edu.gemini.itc.shared.*;
 import edu.gemini.itc.web.HtmlPrinter;
 import edu.gemini.itc.web.ITCRequest;

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/niri/Niri.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/niri/Niri.java
@@ -1,7 +1,7 @@
 package edu.gemini.itc.niri;
 
-import edu.gemini.itc.service.ObservationDetails;
-import edu.gemini.itc.service.CalculationMethod;
+import edu.gemini.itc.shared.ObservationDetails;
+import edu.gemini.itc.shared.CalculationMethod;
 import edu.gemini.itc.shared.*;
 
 import java.util.Iterator;

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/niri/NiriParameters.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/niri/NiriParameters.java
@@ -1,6 +1,6 @@
 package edu.gemini.itc.niri;
 
-import edu.gemini.itc.service.InstrumentDetails;
+import edu.gemini.itc.shared.InstrumentDetails;
 import edu.gemini.itc.shared.ITCMultiPartParser;
 import edu.gemini.itc.shared.ITCParameters;
 

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/niri/NiriRecipe.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/niri/NiriRecipe.java
@@ -2,7 +2,6 @@ package edu.gemini.itc.niri;
 
 import edu.gemini.itc.altair.*;
 import edu.gemini.itc.operation.*;
-import edu.gemini.itc.service.*;
 import edu.gemini.itc.shared.*;
 import edu.gemini.itc.web.HtmlPrinter;
 import edu.gemini.itc.web.ITCRequest;

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/operation/ImageQualityCalculation.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/operation/ImageQualityCalculation.java
@@ -1,6 +1,6 @@
 package edu.gemini.itc.operation;
 
-import edu.gemini.itc.service.TelescopeDetails;
+import edu.gemini.itc.shared.TelescopeDetails;
 import edu.gemini.itc.shared.ArraySpectrum;
 import edu.gemini.itc.shared.DefaultArraySpectrum;
 import edu.gemini.itc.shared.FormatStringWriter;

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/operation/ImageQualityCalculationFactory.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/operation/ImageQualityCalculationFactory.java
@@ -1,8 +1,8 @@
 package edu.gemini.itc.operation;
 
-import edu.gemini.itc.service.ObservingConditions;
-import edu.gemini.itc.service.SourceDefinition;
-import edu.gemini.itc.service.TelescopeDetails;
+import edu.gemini.itc.shared.ObservingConditions;
+import edu.gemini.itc.shared.SourceDefinition;
+import edu.gemini.itc.shared.TelescopeDetails;
 import edu.gemini.itc.shared.Instrument;
 
 public final class ImageQualityCalculationFactory {

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/operation/ImagingPointS2NMethodBCalculation.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/operation/ImagingPointS2NMethodBCalculation.java
@@ -1,6 +1,6 @@
 package edu.gemini.itc.operation;
 
-import edu.gemini.itc.service.ObservationDetails;
+import edu.gemini.itc.shared.ObservationDetails;
 import edu.gemini.itc.shared.FormatStringWriter;
 import edu.gemini.itc.shared.Instrument;
 

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/operation/ImagingS2NCalculation.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/operation/ImagingS2NCalculation.java
@@ -2,7 +2,7 @@ package edu.gemini.itc.operation;
 
 import edu.gemini.itc.gsaoi.Gsaoi;
 import edu.gemini.itc.niri.Niri;
-import edu.gemini.itc.service.ObservationDetails;
+import edu.gemini.itc.shared.ObservationDetails;
 import edu.gemini.itc.shared.BinningProvider;
 import edu.gemini.itc.shared.FormatStringWriter;
 import edu.gemini.itc.shared.Instrument;

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/operation/ImagingS2NCalculationFactory.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/operation/ImagingS2NCalculationFactory.java
@@ -1,6 +1,6 @@
 package edu.gemini.itc.operation;
 
-import edu.gemini.itc.service.ObservationDetails;
+import edu.gemini.itc.shared.ObservationDetails;
 import edu.gemini.itc.shared.Instrument;
 
 public final class ImagingS2NCalculationFactory {

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/operation/ImagingS2NMethodACalculation.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/operation/ImagingS2NMethodACalculation.java
@@ -1,6 +1,6 @@
 package edu.gemini.itc.operation;
 
-import edu.gemini.itc.service.ObservationDetails;
+import edu.gemini.itc.shared.ObservationDetails;
 import edu.gemini.itc.shared.FormatStringWriter;
 import edu.gemini.itc.shared.Instrument;
 

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/operation/NormalizeVisitor.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/operation/NormalizeVisitor.java
@@ -1,9 +1,9 @@
 package edu.gemini.itc.operation;
 
-import edu.gemini.itc.service.SourceDefinition;
+import edu.gemini.itc.shared.BrightnessUnit;
+import edu.gemini.itc.shared.WavebandDefinition;
 import edu.gemini.itc.shared.SampledSpectrum;
 import edu.gemini.itc.shared.SampledSpectrumVisitor;
-import edu.gemini.itc.service.WavebandDefinition;
 import edu.gemini.itc.shared.ZeroMagnitudeStar;
 
 /**
@@ -15,7 +15,7 @@ import edu.gemini.itc.shared.ZeroMagnitudeStar;
 public class NormalizeVisitor implements SampledSpectrumVisitor {
     private final WavebandDefinition _band; // String description of waveband (A, B, R, etc.)
     private final double _user_norm; // Brightness of the object (flux) as an average
-    private final SourceDefinition.BrightnessUnit _units;  // mag, abmag, ...
+    private final BrightnessUnit _units;  // mag, abmag, ...
 
     /**
      * Constructs a Normalizer
@@ -24,7 +24,7 @@ public class NormalizeVisitor implements SampledSpectrumVisitor {
      * @param user_norm The average flux in the waveband
      * @param units     The code for the units chosen by user
      */
-    public NormalizeVisitor(final WavebandDefinition waveband, final double user_norm, final SourceDefinition.BrightnessUnit units) {
+    public NormalizeVisitor(final WavebandDefinition waveband, final double user_norm, final BrightnessUnit units) {
         _band = waveband;
         _user_norm = user_norm;
         _units = units;

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/operation/PeakPixelFlux.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/operation/PeakPixelFlux.java
@@ -1,7 +1,7 @@
 package edu.gemini.itc.operation;
 
-import edu.gemini.itc.service.ObservationDetails;
-import edu.gemini.itc.service.SourceDefinition;
+import edu.gemini.itc.shared.ObservationDetails;
+import edu.gemini.itc.shared.SourceDefinition;
 import edu.gemini.itc.shared.DatFile;
 import edu.gemini.itc.shared.ITCConstants;
 import edu.gemini.itc.shared.Instrument;

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/operation/SourceFractionFactory.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/operation/SourceFractionFactory.java
@@ -1,7 +1,7 @@
 package edu.gemini.itc.operation;
 
-import edu.gemini.itc.service.ObservationDetails;
-import edu.gemini.itc.service.SourceDefinition;
+import edu.gemini.itc.shared.ObservationDetails;
+import edu.gemini.itc.shared.SourceDefinition;
 import edu.gemini.itc.shared.Instrument;
 
 public final class SourceFractionFactory {

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/operation/TelescopeBackgroundVisitor.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/operation/TelescopeBackgroundVisitor.java
@@ -1,6 +1,6 @@
 package edu.gemini.itc.operation;
 
-import edu.gemini.itc.service.TelescopeDetails;
+import edu.gemini.itc.shared.TelescopeDetails;
 import edu.gemini.itc.shared.*;
 import edu.gemini.spModel.core.Site;
 

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/operation/TelescopeTransmissionVisitor.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/operation/TelescopeTransmissionVisitor.java
@@ -1,6 +1,6 @@
 package edu.gemini.itc.operation;
 
-import edu.gemini.itc.service.TelescopeDetails;
+import edu.gemini.itc.shared.TelescopeDetails;
 import edu.gemini.itc.shared.ITCConstants;
 import edu.gemini.itc.shared.TransmissionElement;
 

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/shared/BlackBodySpectrum.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/shared/BlackBodySpectrum.java
@@ -1,8 +1,5 @@
 package edu.gemini.itc.shared;
 
-import edu.gemini.itc.service.SourceDefinition;
-import edu.gemini.itc.service.WavebandDefinition;
-
 /**
  * This class creates a black body spectrum over the interval defined by the
  * blocking filter.  The code comes from Inger Jorgensen and Tom Geballe's
@@ -17,7 +14,7 @@ public class BlackBodySpectrum implements VisitableSampledSpectrum {
         _spectrum = spectrum;
     }
 
-    public BlackBodySpectrum(double temp, double interval, double flux, SourceDefinition.BrightnessUnit units, WavebandDefinition band, double z) {
+    public BlackBodySpectrum(double temp, double interval, double flux, BrightnessUnit units, WavebandDefinition band, double z) {
 
         //rescale the start and end depending on the redshift
         final double start = 300 / (1 + z);
@@ -69,7 +66,7 @@ public class BlackBodySpectrum implements VisitableSampledSpectrum {
     }
 
 
-    private double _convertToMag(final double flux, final SourceDefinition.BrightnessUnit units, final WavebandDefinition band) {
+    private double _convertToMag(final double flux, final BrightnessUnit units, final WavebandDefinition band) {
         //THis method should convert the flux into units of magnitude.
         //same code as in NormalizeVisitor.java.  Eventually should come out
         // into a genral purpose conversion class if needs to be used again.

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/shared/EmissionLineSpectrum.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/shared/EmissionLineSpectrum.java
@@ -1,7 +1,5 @@
 package edu.gemini.itc.shared;
 
-import edu.gemini.itc.service.SourceDefinition;
-
 /**
  * This class creates a EmissionLine spectrum over the interval defined by the
  * blocking filter.  The code comes from PPuxley's Mathcad Demo

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/shared/ITCChart.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/shared/ITCChart.java
@@ -1,6 +1,5 @@
 package edu.gemini.itc.shared;
 
-import edu.gemini.itc.service.PlottingDetails;
 import org.jfree.chart.ChartFactory;
 import org.jfree.chart.JFreeChart;
 import org.jfree.chart.plot.PlotOrientation;

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/shared/MultipartTestServlet.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/shared/MultipartTestServlet.java
@@ -1,10 +1,6 @@
 package edu.gemini.itc.shared;
 
 import edu.gemini.itc.acqcam.AcquisitionCamParameters;
-import edu.gemini.itc.service.ObservationDetails;
-import edu.gemini.itc.service.ObservingConditions;
-import edu.gemini.itc.service.SourceDefinition;
-import edu.gemini.itc.service.TelescopeDetails;
 import edu.gemini.itc.web.ITCRequest;
 
 import javax.servlet.ServletConfig;

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/shared/SEDFactory.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/shared/SEDFactory.java
@@ -5,7 +5,6 @@ import edu.gemini.itc.gsaoi.Gsaoi;
 import edu.gemini.itc.nifs.Nifs;
 import edu.gemini.itc.niri.Niri;
 import edu.gemini.itc.operation.*;
-import edu.gemini.itc.service.*;
 import edu.gemini.spModel.core.Site;
 import scala.Option;
 

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/shared/ZeroMagnitudeStar.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/shared/ZeroMagnitudeStar.java
@@ -1,7 +1,5 @@
 package edu.gemini.itc.shared;
 
-import edu.gemini.itc.service.WavebandDefinition;
-
 /**
  * This class encapsulates the photon flux density (in photons/s/m^2/nm)
  * for a zero-magnitude star.

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/trecs/TRecs.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/trecs/TRecs.java
@@ -1,8 +1,8 @@
 package edu.gemini.itc.trecs;
 
 import edu.gemini.itc.operation.DetectorsTransmissionVisitor;
-import edu.gemini.itc.service.ObservationDetails;
-import edu.gemini.itc.service.CalculationMethod;
+import edu.gemini.itc.shared.ObservationDetails;
+import edu.gemini.itc.shared.CalculationMethod;
 import edu.gemini.itc.shared.*;
 import scala.Option;
 

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/trecs/TRecsParameters.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/trecs/TRecsParameters.java
@@ -1,6 +1,6 @@
 package edu.gemini.itc.trecs;
 
-import edu.gemini.itc.service.InstrumentDetails;
+import edu.gemini.itc.shared.InstrumentDetails;
 import edu.gemini.itc.shared.ITCMultiPartParser;
 import edu.gemini.itc.shared.ITCParameters;
 

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/trecs/TRecsRecipe.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/trecs/TRecsRecipe.java
@@ -1,7 +1,6 @@
 package edu.gemini.itc.trecs;
 
 import edu.gemini.itc.operation.*;
-import edu.gemini.itc.service.*;
 import edu.gemini.itc.shared.*;
 import edu.gemini.itc.web.HtmlPrinter;
 import edu.gemini.itc.web.ITCRequest;

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/web/HtmlPrinter.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/web/HtmlPrinter.java
@@ -1,12 +1,12 @@
 package edu.gemini.itc.web;
 
-import edu.gemini.itc.service.ObservationDetails;
-import edu.gemini.itc.service.ObservingConditions;
-import edu.gemini.itc.service.PlottingDetails;
-import edu.gemini.itc.service.TelescopeDetails;
-import edu.gemini.itc.service.SourceDefinition;
+import edu.gemini.itc.shared.ObservationDetails;
+import edu.gemini.itc.shared.ObservingConditions;
+import edu.gemini.itc.shared.PlottingDetails;
+import edu.gemini.itc.shared.TelescopeDetails;
+import edu.gemini.itc.shared.SourceDefinition;
 import edu.gemini.itc.shared.FormatStringWriter;
-import edu.gemini.itc.service.Library;
+import edu.gemini.itc.shared.Library;
 import edu.gemini.spModel.telescope.IssPort;
 
 /**

--- a/bundle/edu.gemini.itc/src/main/scala/edu/gemini/itc/osgi/Activator.scala
+++ b/bundle/edu.gemini.itc/src/main/scala/edu/gemini/itc/osgi/Activator.scala
@@ -4,7 +4,8 @@ import java.util.logging.Level._
 import java.util.logging.Logger
 
 import edu.gemini.itc.osgi.Activator._
-import edu.gemini.itc.service.{ItcService, ItcServiceImpl}
+import edu.gemini.itc.service.ItcServiceImpl
+import edu.gemini.itc.shared.ItcService
 import org.osgi.framework.{BundleActivator, BundleContext, ServiceRegistration}
 
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -29,7 +30,8 @@ class Activator extends BundleActivator {
     // register the services..
     Future {
 
-      val properties = new java.util.Hashtable[String, Object]() {{ put("trpc", "")}}
+     val properties = new java.util.Hashtable[String, Object]()
+      properties.put("trpc", "")
       val service    = new ItcServiceImpl()
       ctx.registerService(classOf[ItcService], service, properties)
 

--- a/bundle/edu.gemini.itc/src/main/scala/edu/gemini/itc/service/ItcServiceImpl.scala
+++ b/bundle/edu.gemini.itc/src/main/scala/edu/gemini/itc/service/ItcServiceImpl.scala
@@ -2,6 +2,7 @@ package edu.gemini.itc.service
 
 import edu.gemini.itc.gmos.GmosRecipe
 import edu.gemini.itc.operation.ImagingS2NMethodACalculation
+import edu.gemini.itc.shared._
 
 /**
  * The ITC service implementation.
@@ -21,7 +22,9 @@ class ItcServiceImpl extends ItcService {
     }
   } catch {
     // TODO: for now in most cases where a validation problem should be reported to the user the ITC code throws an exception instead
-    case e: Throwable => ItcResult.forException(e)
+    case e: Throwable =>
+      e.printStackTrace()
+      ItcResult.forException(e)
   }
 
   private def calculateGmos(source: SourceDefinition, obs: ObservationDetails, cond: ObservingConditions, tele: TelescopeDetails, ins: GmosParameters): Result = {

--- a/bundle/edu.gemini.itc/src/main/scala/edu/gemini/itc/web/ITCRequest.scala
+++ b/bundle/edu.gemini.itc/src/main/scala/edu/gemini/itc/web/ITCRequest.scala
@@ -3,7 +3,8 @@ package edu.gemini.itc.web
 import javax.servlet.http.HttpServletRequest
 
 import edu.gemini.itc.altair.AltairParameters
-import edu.gemini.itc.service.SourceDefinition._
+import edu.gemini.itc.shared._
+import SourceDefinition._
 import edu.gemini.itc.service._
 import edu.gemini.itc.shared._
 import edu.gemini.spModel.core.Site
@@ -160,7 +161,7 @@ object ITCRequest {
     val pc = ITCRequest.from(r)
 
     // Get the source geometry and type
-    import edu.gemini.itc.service.SourceDefinition.Profile._
+    import SourceDefinition.Profile._
     val spatialProfile = pc.enumParameter(classOf[Profile]) match {
       case POINT    =>
         val norm  = pc.doubleParameter("psSourceNorm")
@@ -181,7 +182,7 @@ object ITCRequest {
     val normBand = pc.enumParameter(classOf[WavebandDefinition])
 
     // Get Spectrum Resource
-    import edu.gemini.itc.service.SourceDefinition.Distribution._
+    import SourceDefinition.Distribution._
     val sourceSpec = pc.enumParameter(classOf[Distribution])
     val sourceDefinition = sourceSpec match {
       case BBODY =>             BlackBody(pc.doubleParameter("BBTemp"))
@@ -200,7 +201,7 @@ object ITCRequest {
     }
 
     //Get Redshift
-    import edu.gemini.itc.service.SourceDefinition.Recession._
+    import SourceDefinition.Recession._
     val recession = pc.enumParameter(classOf[Recession])
     val redshift = recession match {
       case REDSHIFT => pc.doubleParameter("z")

--- a/bundle/edu.gemini.itc/src/test/scala/edu/gemini/itc/baseline/BaselineAllSpec.scala
+++ b/bundle/edu.gemini.itc/src/test/scala/edu/gemini/itc/baseline/BaselineAllSpec.scala
@@ -9,7 +9,7 @@ import edu.gemini.itc.gsaoi.GsaoiParameters
 import edu.gemini.itc.michelle.MichelleParameters
 import edu.gemini.itc.nifs.NifsParameters
 import edu.gemini.itc.niri.NiriParameters
-import edu.gemini.itc.service.GmosParameters
+import edu.gemini.itc.shared.GmosParameters
 import edu.gemini.itc.trecs.TRecsParameters
 import org.scalacheck.{Arbitrary, Gen}
 import org.specs2.ScalaCheck

--- a/bundle/edu.gemini.itc/src/test/scala/edu/gemini/itc/baseline/BaselineGmos.scala
+++ b/bundle/edu.gemini.itc/src/test/scala/edu/gemini/itc/baseline/BaselineGmos.scala
@@ -3,7 +3,7 @@ package edu.gemini.itc.baseline
 import edu.gemini.itc.baseline.util.Baseline._
 import edu.gemini.itc.baseline.util._
 import edu.gemini.itc.gmos.GmosRecipe
-import edu.gemini.itc.service.{GmosParameters, IfuRadial, IfuSingle}
+import edu.gemini.itc.shared.{GmosParameters, IfuRadial, IfuSingle}
 import edu.gemini.spModel.core.Site
 import edu.gemini.spModel.gemini.gmos.GmosCommonType.DetectorManufacturer
 import edu.gemini.spModel.gemini.gmos.GmosNorthType.{DisperserNorth, FPUnitNorth, FilterNorth}

--- a/bundle/edu.gemini.itc/src/test/scala/edu/gemini/itc/baseline/util/Baseline.scala
+++ b/bundle/edu.gemini.itc/src/test/scala/edu/gemini/itc/baseline/util/Baseline.scala
@@ -1,9 +1,7 @@
 package edu.gemini.itc.baseline.util
 
 import java.io.{ByteArrayOutputStream, File, PrintWriter}
-
-import edu.gemini.itc.service.InstrumentDetails
-import edu.gemini.itc.shared.{ITCImageFileIO, Recipe}
+import edu.gemini.itc.shared.{InstrumentDetails, ITCImageFileIO, Recipe}
 
 import scala.io.Source
 

--- a/bundle/edu.gemini.itc/src/test/scala/edu/gemini/itc/baseline/util/BaselineTest.scala
+++ b/bundle/edu.gemini.itc/src/test/scala/edu/gemini/itc/baseline/util/BaselineTest.scala
@@ -1,7 +1,7 @@
 package edu.gemini.itc.baseline.util
 
 import edu.gemini.itc.baseline._
-import edu.gemini.itc.service.InstrumentDetails
+import edu.gemini.itc.shared.InstrumentDetails
 import org.junit.Assert._
 import org.junit.{Ignore, Test}
 

--- a/bundle/edu.gemini.itc/src/test/scala/edu/gemini/itc/baseline/util/Fixture.scala
+++ b/bundle/edu.gemini.itc/src/test/scala/edu/gemini/itc/baseline/util/Fixture.scala
@@ -2,9 +2,7 @@ package edu.gemini.itc.baseline.util
 
 import edu.gemini.itc.altair.AltairParameters
 import edu.gemini.itc.gems.GemsParameters
-import edu.gemini.itc.service.SourceDefinition.BrightnessUnit
-import edu.gemini.itc.service.TelescopeDetails.{Coating, Wfs}
-import edu.gemini.itc.service._
+import edu.gemini.itc.shared.TelescopeDetails.{Coating, Wfs}
 import edu.gemini.itc.shared._
 import edu.gemini.spModel.gemini.altair.AltairParams.{FieldLens, GuideStarType}
 import edu.gemini.spModel.telescope.IssPort

--- a/bundle/edu.gemini.itc/src/test/scala/edu/gemini/itc/baseline/util/Hash.scala
+++ b/bundle/edu.gemini.itc/src/test/scala/edu/gemini/itc/baseline/util/Hash.scala
@@ -10,6 +10,7 @@ import edu.gemini.itc.michelle.MichelleParameters
 import edu.gemini.itc.nifs.NifsParameters
 import edu.gemini.itc.niri.NiriParameters
 import edu.gemini.itc.service._
+import edu.gemini.itc.shared._
 import edu.gemini.itc.trecs.TRecsParameters
 
 // TEMPORARY helper

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/data/AbstractDataObject.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/data/AbstractDataObject.java
@@ -95,6 +95,12 @@ public class AbstractDataObject implements ISPCloneable, ISPDataObject, Serializ
         return result;
     }
 
+    @SuppressWarnings("unchecked")
+    @Override
+    public <A extends ISPDataObject> A clone(A a) {
+        return (A) a.clone();
+    }
+
     /**
      * Get the item's type.  SpType is like an enumerated type in C++.  Each
      * type is mapped one-to-one with its own object.

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/data/ISPDataObject.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/data/ISPDataObject.java
@@ -7,6 +7,7 @@
 //
 package edu.gemini.spModel.data;
 
+import edu.gemini.pot.sp.ISPCloneable;
 import edu.gemini.pot.sp.SPComponentType;
 import edu.gemini.spModel.pio.ParamSet;
 import edu.gemini.spModel.pio.PioFactory;
@@ -32,7 +33,7 @@ import java.io.Serializable;
  * (and other formats).  A property list is expected upon export and
  * passed to a constructor when creating the data object.
  */
-public interface ISPDataObject extends Serializable {
+public interface ISPDataObject extends ISPCloneable, Serializable {
 
     /**
      * Names the version property of all data objects.
@@ -137,4 +138,11 @@ public interface ISPDataObject extends Serializable {
      * type is mapped one-to-one with its own object.
      */
     SPComponentType getType();
+
+    /**
+     * A clone method that is callable from Scala and that hides the cast to the
+     * desired type.
+     * https://issues.scala-lang.org/browse/SI-6760
+     */
+    <A extends ISPDataObject> A clone(A a);
 }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gmos/GmosOiwfsGuideProbe.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gmos/GmosOiwfsGuideProbe.java
@@ -131,8 +131,7 @@ public enum GmosOiwfsGuideProbe implements ValidatableGuideProbe, OffsetValidati
     public double calculateVignetting(final ObsContext ctx,
                                       final edu.gemini.spModel.core.Coordinates guideStarCoordinates) {
         final ProbeArmGeometry probeArmGeometry       = GmosOiwfsProbeArm.instance();
-        final ScienceAreaGeometry scienceAreaGeometry = new GmosScienceAreaGeometry();
-        return ScalaGuideProbeUtil.calculateVignetting(ctx, guideStarCoordinates, scienceAreaGeometry, probeArmGeometry);
+        return ScalaGuideProbeUtil.calculateVignetting(ctx, guideStarCoordinates, probeArmGeometry);
     }
 
     private PatrolField getCorrectedPatrolField(final ObsContext ctx, final PatrolField patrolField) {

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gmos/InstGmosCommon.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gmos/InstGmosCommon.java
@@ -26,6 +26,8 @@ import edu.gemini.spModel.gemini.calunit.calibration.CalDictionary;
 import edu.gemini.spModel.gemini.parallacticangle.ParallacticAngleSupportInst;
 import edu.gemini.spModel.guide.GuideProbe;
 import edu.gemini.spModel.guide.GuideProbeProvider;
+import edu.gemini.spModel.inst.ScienceAreaGeometry;
+import edu.gemini.spModel.inst.VignettableScienceAreaInstrument;
 import edu.gemini.spModel.obs.plannedtime.CommonStepCalculator;
 import edu.gemini.spModel.obs.plannedtime.ExposureCalculator;
 import edu.gemini.spModel.obs.plannedtime.PlannedTime.CategorizedTime;
@@ -64,7 +66,8 @@ public abstract class InstGmosCommon<
         F extends Enum<F> & GmosCommonType.Filter,
         P extends Enum<P> & GmosCommonType.FPUnit,
         SM extends Enum<SM> & GmosCommonType.StageMode>
-        extends ParallacticAngleSupportInst implements IOffsetPosListProvider<OffsetPos>, GuideProbeProvider, IssPortProvider, PosAngleConstraintAware, StepCalculator {
+        extends ParallacticAngleSupportInst implements IOffsetPosListProvider<OffsetPos>, GuideProbeProvider,
+            IssPortProvider, PosAngleConstraintAware, StepCalculator, VignettableScienceAreaInstrument<InstGmosCommon> {
 
     private static final Logger LOG = Logger.getLogger(InstGmosCommon.class.getName());
 
@@ -99,7 +102,6 @@ public abstract class InstGmosCommon<
     // The size of the detector in arc secs
     public static final double DETECTOR_WIDTH = 330.34;
     public static final double DETECTOR_HEIGHT = 330.34;
-
 
     // Properties
     public static final PropertyDescriptor AMP_COUNT_PROP;
@@ -372,7 +374,6 @@ public abstract class InstGmosCommon<
             }
     );
 
-
     /**
      * Constructor
      */
@@ -445,13 +446,7 @@ public abstract class InstGmosCommon<
      * Return the science area based upon the current camera.
      */
     public double[] getScienceArea() {
-        double[] size = {330.34, 330.34};
-        P fpu = getFPUnit();
-        double width = fpu.getWidth();
-        if (width != -1)
-            size[0] = width;
-
-        return size;
+        return new GmosScienceAreaGeometry(this).scienceAreaDimensionsAsJava();
     }
 
     /**
@@ -2040,4 +2035,8 @@ public abstract class InstGmosCommon<
         }
     }
 
+    @Override
+    public ScienceAreaGeometry<InstGmosCommon> getVignettableScienceArea() {
+        return new GmosScienceAreaGeometry(this);
+    }
 }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gmos/InstGmosNorth.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gmos/InstGmosNorth.java
@@ -20,6 +20,8 @@ import edu.gemini.spModel.gemini.gmos.GmosNorthType.DisperserNorth;
 import edu.gemini.spModel.gemini.gmos.GmosNorthType.FilterNorth;
 import edu.gemini.spModel.guide.GuideProbe;
 import edu.gemini.spModel.guide.GuideProbeUtil;
+import edu.gemini.spModel.inst.ScienceAreaGeometry;
+import edu.gemini.spModel.inst.VignettableScienceAreaInstrument;
 import edu.gemini.spModel.obscomp.InstConfigInfo;
 
 import java.beans.IntrospectionException;
@@ -34,7 +36,8 @@ public class InstGmosNorth extends
         InstGmosCommon<GmosNorthType.DisperserNorth,
                 GmosNorthType.FilterNorth,
                 GmosNorthType.FPUnitNorth,
-                GmosNorthType.StageModeNorth> implements PropertyProvider, CalibrationKeyProvider {
+                GmosNorthType.StageModeNorth>
+        implements PropertyProvider, CalibrationKeyProvider {
     private static final Logger LOG = Logger.getLogger(InstGmosCommon.class.getName());
 
     public static final SPComponentType SP_TYPE =

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gmos/InstGmosNorth.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gmos/InstGmosNorth.java
@@ -20,8 +20,6 @@ import edu.gemini.spModel.gemini.gmos.GmosNorthType.DisperserNorth;
 import edu.gemini.spModel.gemini.gmos.GmosNorthType.FilterNorth;
 import edu.gemini.spModel.guide.GuideProbe;
 import edu.gemini.spModel.guide.GuideProbeUtil;
-import edu.gemini.spModel.inst.ScienceAreaGeometry;
-import edu.gemini.spModel.inst.VignettableScienceAreaInstrument;
 import edu.gemini.spModel.obscomp.InstConfigInfo;
 
 import java.beans.IntrospectionException;

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/inst/VignettableScienceAreaInstrument.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/inst/VignettableScienceAreaInstrument.java
@@ -1,0 +1,7 @@
+package edu.gemini.spModel.inst;
+
+import edu.gemini.spModel.obscomp.SPInstObsComp;
+
+public interface VignettableScienceAreaInstrument<I extends SPInstObsComp> {
+    public ScienceAreaGeometry<I> getVignettableScienceArea();
+}

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/flamingos2/F2ScienceAreaGeometry.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/flamingos2/F2ScienceAreaGeometry.scala
@@ -1,0 +1,109 @@
+package edu.gemini.spModel.gemini.flamingos2
+
+import java.awt.Shape
+import java.awt.geom.{Rectangle2D, Area, Ellipse2D}
+
+import edu.gemini.shared.util.immutable.DefaultImList
+import edu.gemini.spModel.gemini.flamingos2.Flamingos2.{FPUnit, LyotWheel}
+import edu.gemini.spModel.inst.ScienceAreaGeometry
+
+import scala.collection.JavaConverters._
+
+class F2ScienceAreaGeometry(inst0: Flamingos2) extends ScienceAreaGeometry[Flamingos2] {
+  import F2ScienceAreaGeometry._
+
+  override def geometry: List[Shape] = {
+    Option(inst0).toList.flatMap { inst =>
+      lazy val plateScale = inst.getLyotWheel.getPlateScale
+      lazy val scienceAreaWidth = {
+        val scienceAreaArray = inst.getScienceArea
+        scienceAreaArray(0)
+      }
+      inst.getFpu match {
+        case Flamingos2.FPUnit.FPU_NONE    => List(imagingFOV(plateScale))
+        case Flamingos2.FPUnit.CUSTOM_MASK => List(mosFOV(plateScale))
+        case _ if inst.getFpu.isLongslit   => List(longSlitFOV(plateScale, scienceAreaWidth))
+        case _                             => Nil
+      }
+    }
+  }
+
+  // We need to override this due to type system.
+  override def geometryAsJava: edu.gemini.shared.util.immutable.ImList[Shape] =
+    DefaultImList.create(geometry.asJava)
+
+  def scienceAreaDimensions: (Double, Double) = {
+    Option(inst0).map { inst =>
+      val lyotWheel = inst.getLyotWheel
+      if (Set(LyotWheel.OPEN, LyotWheel.HIGH, LyotWheel.LOW).contains(lyotWheel)) {
+        lazy val plateScale = lyotWheel.getPlateScale
+        inst.getFpu match {
+          case FPUnit.FPU_NONE =>
+            val size = ImagingFOVSize * plateScale
+            (size, size)
+          case FPUnit.CUSTOM_MASK =>
+            (MOSFOVWidth * plateScale, ImagingFOVSize * plateScale)
+          case fpu if fpu.isLongslit =>
+            (fpu.getSlitWidth * lyotWheel.getPixelScale, LongSlitFOVHeight * plateScale)
+          case _ =>
+            (0.0, 0.0)
+        }
+      } else (0.0, 0.0)
+    }.getOrElse(0.0, 0.0)
+  }
+
+  /**
+   * Create the F2 imaging field of view.
+   * @param plateScale the plate scale in arcsec/mm
+   * @return           a shape representing the FOV
+   */
+  private def imagingFOV(plateScale: Double): Shape = {
+    val size   = ImagingFOVSize * plateScale
+    val radius = size / 2.0
+    new Ellipse2D.Double(-radius, -radius, size, size)
+  }
+
+  /**
+   * Create the F2 MOS field of view shape.
+   * @param plateScale the plate scale in arcsec/mm
+   * @return           a shape representing the FOV
+   */
+  private def mosFOV(plateScale: Double): Shape = {
+    val width  = MOSFOVWidth * plateScale
+    val height = ImagingFOVSize * plateScale
+    val radius = height / 2.0
+
+    // The FOV is the intersection of a rectangle and a circle.
+    val circle = new Ellipse2D.Double(-radius, -radius, height, height)
+    val rectangle = new Rectangle2D.Double(-width/2.0, -radius, width, height)
+
+    val area = new Area(circle)
+    area.intersect(new Area(rectangle))
+    area
+  }
+
+  /**
+   * Create the F2 long slit field of view shape.
+   * @param plateScale       the plate scale in arcsec/mm
+   * @param scienceAreaWidth the width of the science area for the F2 configuration
+   * @return                 a shape representing the FOV
+   */
+  private def longSlitFOV(plateScale: Double, scienceAreaWidth: Double): Shape = {
+    val slitHeight = LongSlitFOVHeight * plateScale
+    val slitSouth  = LongSlitFOVSouthPos * plateScale
+
+    val x = -scienceAreaWidth / 2.0
+    val y = slitSouth - slitHeight
+    new Rectangle2D.Double(x, y, x + scienceAreaWidth, y + slitHeight)
+  }
+
+}
+
+object F2ScienceAreaGeometry {
+  // Geometry features for F2, in arcseconds.
+  val LongSlitFOVHeight   = 164.1
+  val LongSlitFOVSouthPos = 112.0
+  val LongSlitFOVNorthPos = 52.1
+  val ImagingFOVSize      = 230.12
+  val MOSFOVWidth         = 75.16
+}

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/flamingos2/F2ScienceAreaGeometry.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/flamingos2/F2ScienceAreaGeometry.scala
@@ -49,7 +49,7 @@ class F2ScienceAreaGeometry(inst0: Flamingos2) extends ScienceAreaGeometry[Flami
             (0.0, 0.0)
         }
       } else (0.0, 0.0)
-    }.getOrElse(0.0, 0.0)
+    }.getOrElse((0.0, 0.0))
   }
 
   /**

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/gmos/GmosOiwfsProbeArm.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/gmos/GmosOiwfsProbeArm.scala
@@ -1,7 +1,7 @@
 package edu.gemini.spModel.gemini.gmos
 
 import java.awt.Shape
-import java.awt.geom.{Point2D, AffineTransform}
+import java.awt.geom.{Rectangle2D, Point2D, AffineTransform}
 import java.text.DecimalFormat
 
 import edu.gemini.pot.ModelConverters._
@@ -39,13 +39,8 @@ object GmosOiwfsProbeArm extends ProbeArmGeometry {
   }
 
   private lazy val pickoffMirror: Shape = {
-    val (x0, y0) = (-PickoffMirrorSize / 2.0, -PickoffMirrorSize / 2.0)
-    val (x1, y1) = (x0 + PickoffMirrorSize,   y0)
-    val (x2, y2) = (x1,                       y1 + PickoffMirrorSize)
-    val (x3, y3) = (x0,                       y2)
-
-    val points = List((x0,y0), (x1,y1), (x2,y2), (x3,y3))
-    ImPolygon(points)
+    val xy = -PickoffMirrorSize / 2.0
+    new Rectangle2D.Double(xy, xy, PickoffMirrorSize, PickoffMirrorSize)
   }
 
   override def armAdjustment(ctx0: ObsContext, guideStarCoords: Coordinates, offset0: Offset): Option[ArmAdjustment] = {

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/gmos/GmosScienceAreaGeometry.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/gmos/GmosScienceAreaGeometry.scala
@@ -43,7 +43,7 @@ class GmosScienceAreaGeometry[I  <: InstGmosCommon[D,F,P,SM],
         (ImagingFOVSize, width)
       else
         (ImagingFOVSize, ImagingFOVSize)
-    }.getOrElse(0.0, 0.0)
+    }.getOrElse((0.0, 0.0))
   }
 
   /**

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/gmos/GmosScienceAreaGeometry.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/gmos/GmosScienceAreaGeometry.scala
@@ -17,7 +17,7 @@ class GmosScienceAreaGeometry[I  <: InstGmosCommon[D,F,P,SM],
   import GmosScienceAreaGeometry._
 
   override def geometry: List[Shape] = {
-    Option(inst0).toList.flatMap { inst =>
+    Option(inst0).fold(List[Shape]()) { inst =>
       lazy val width   = inst.getScienceArea()(0)
       lazy val isSouth = inst.getSite.contains(Site.GS)
       inst.getFPUnitMode match {

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/gmos/GmosScienceAreaGeometry.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/gmos/GmosScienceAreaGeometry.scala
@@ -13,11 +13,11 @@ class GmosScienceAreaGeometry[I  <: InstGmosCommon[D,F,P,SM],
                               D  <: Enum[D]  with GmosCommonType.Disperser,
                               F  <: Enum[F]  with GmosCommonType.Filter,
                               P  <: Enum[P]  with GmosCommonType.FPUnit,
-                              SM <: Enum[SM] with GmosCommonType.StageMode](inst: I) extends ScienceAreaGeometry[I] {
+                              SM <: Enum[SM] with GmosCommonType.StageMode](inst0: I) extends ScienceAreaGeometry[I] {
   import GmosScienceAreaGeometry._
 
   override def geometry: List[Shape] = {
-    Option(inst).toList.flatMap { inst =>
+    Option(inst0).toList.flatMap { inst =>
       lazy val width   = inst.getScienceArea()(0)
       lazy val isSouth = inst.getSite.contains(Site.GS)
       inst.getFPUnitMode match {
@@ -37,11 +37,13 @@ class GmosScienceAreaGeometry[I  <: InstGmosCommon[D,F,P,SM],
     DefaultImList.create(geometry.asJava)
 
   override def scienceAreaDimensions: (Double, Double) = {
-    val width = inst.getFPUnit.getWidth
-    if (width != -1)
-      (ImagingFOVSize, width)
-    else
-      (ImagingFOVSize, ImagingFOVSize)
+    Option(inst0).map { inst =>
+      val width = inst.getFPUnit.getWidth
+      if (width != -1)
+        (ImagingFOVSize, width)
+      else
+        (ImagingFOVSize, ImagingFOVSize)
+    }.getOrElse(0.0, 0.0)
   }
 
   /**

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/inst/ScienceAreaGeometry.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/inst/ScienceAreaGeometry.scala
@@ -15,12 +15,28 @@ trait ScienceAreaGeometry[I <: SPInstObsComp] {
    * Create the shapes for the science area based on the instrument configuration.
    * @return a list representing the shapes, or an empty list if no such shape exists
    */
-  def geometry(inst: I): List[Shape]
+  def geometry: List[Shape]
 
   /**
    * Return a list of the shapes comprising the geometry of the science area for Java.
    * @return an immutable list of the shapes, or an empty list if no such shape exists
    */
-  def geometryAsJava(inst: I): edu.gemini.shared.util.immutable.ImList[Shape] =
-    DefaultImList.create(geometry(inst).asJava)
+  def geometryAsJava: edu.gemini.shared.util.immutable.ImList[Shape] =
+    DefaultImList.create(geometry.asJava)
+
+  /**
+   * Return the width and height bounds of the science area in arcsec x arcsec, which is needed by
+   * various editors and P2 checks.
+   * TODO: This is currently called from SPInstObsComp subclass getScienceArea methods.
+   * TODO: Ultimately, when all the science areas are removed, this should be separated out
+   * TODO: from SPInstObsComp and accessed directly through ScienceAreaGeometry instead of
+   * TODO: from the instruments themselves.
+   * @return     a rectangular bound of the size of the science area
+   */
+  def scienceAreaDimensions: (Double, Double)
+
+  def scienceAreaDimensionsAsJava = {
+    val bounds = scienceAreaDimensions
+    Array(bounds._1, bounds._2)
+  }
 }

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/rich/pot/sp/package.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/rich/pot/sp/package.scala
@@ -2,6 +2,7 @@ package edu.gemini.spModel.rich.pot
 
 import edu.gemini.pot.sp._
 import edu.gemini.spModel.core.{RichSpProgramId, SPProgramID}
+import edu.gemini.spModel.data.ISPDataObject
 
 import scalaz._
 import Scalaz._
@@ -41,4 +42,8 @@ package object sp {
   }
 
   implicit def SpNodeKeyEqual: Equal[SPNodeKey] = Equal.equalA
+
+  implicit class RichDataObject[A <: ISPDataObject](dob: A) {
+    def copy: A = dob.clone(dob)
+  }
 }

--- a/bundle/edu.gemini.pot/src/test/java/edu/gemini/pot/spdb/test/TriggerCase.java
+++ b/bundle/edu.gemini.pot/src/test/java/edu/gemini/pot/spdb/test/TriggerCase.java
@@ -9,7 +9,6 @@ import edu.gemini.pot.spdb.IDBTriggerCondition;
 import edu.gemini.spModel.data.ISPDataObject;
 import edu.gemini.spModel.pio.ParamSet;
 import edu.gemini.spModel.pio.PioFactory;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -35,10 +34,25 @@ public class TriggerCase extends SpdbBaseTestCase {
     private static final SPComponentType TRIGGER_TYPE = SPComponentType.INSTRUMENT_FLAMINGOS2; // SPComponentType.getInstance("trigger", "trigger", "trigger");
 
     public static final class ProgramDataObject implements ISPDataObject {
-        private List _triggerList = new ArrayList();
+        private List<String> _triggerList = new ArrayList<>();
+
+        public Object clone() {
+            try {
+                return super.clone();
+            } catch (CloneNotSupportedException e) {
+                throw new InternalError();
+            }
+        }
+
+        @SuppressWarnings("unchecked")
+        @Override
+        public <A extends ISPDataObject> A clone(A a) {
+            return (A) a.clone();
+        }
+
 
         public String[] getTriggerMessages() {
-            return (String[]) _triggerList.toArray(new String[0]);
+            return _triggerList.toArray(new String[_triggerList.size()]);
         }
 
         public void addTriggerMessage(String message) {
@@ -92,6 +106,19 @@ public class TriggerCase extends SpdbBaseTestCase {
 
     public static final class TriggerDataObject implements ISPDataObject, Serializable {
         private String _triggerMessage;
+
+        public Object clone() {
+            try {
+                return super.clone();
+            } catch (CloneNotSupportedException e) {
+                throw new InternalError();
+            }
+        }
+
+        @Override @SuppressWarnings("unchecked")
+        public <A extends ISPDataObject> A clone(A a) {
+            return (A) a.clone();
+        }
 
         public String getTriggerMessage() {
             return _triggerMessage;
@@ -207,7 +234,6 @@ public class TriggerCase extends SpdbBaseTestCase {
     private ISPProgram _prog;
     private ISPObsComponent _triggerComp;
     private ISPObsComponent _nonTriggerComp;
-    private List _leaseList = new ArrayList();
 
     @Before
     public void setUp() throws Exception {
@@ -218,23 +244,10 @@ public class TriggerCase extends SpdbBaseTestCase {
         _triggerComp    = _createObsComponent(_prog, TRIGGER_TYPE);
         _nonTriggerComp = _createObsComponent(_prog, NON_TRIGGER_TYPE);
 
-        List obsCompList = new ArrayList();
+        List<ISPObsComponent> obsCompList = new ArrayList<>();
         obsCompList.add(_triggerComp);
         obsCompList.add(_nonTriggerComp);
         _prog.setObsComponents(obsCompList);
-    }
-
-    @After
-    public void tearDown() throws Exception {
-        super.tearDown();
-
-//        for (Iterator it=_leaseList.iterator(); it.hasNext(); ) {
-//            Lease lease = (Lease) it.next();
-//            try {
-//                lease.cancel();
-//            } catch (Exception ex) {
-//            }
-//        }
     }
 
     private ISPObsComponent _createObsComponent(ISPProgram prog, SPComponentType type)

--- a/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/config/test/TestDataObject.java
+++ b/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/config/test/TestDataObject.java
@@ -19,13 +19,26 @@ import java.beans.PropertyChangeListener;
 import java.io.Serializable;
 
 
-
 public class TestDataObject implements Serializable, IConfigProvider, ISPDataObject {
 
     private ISysConfig _sysConfig;
 
 
     public TestDataObject() {
+    }
+
+    public Object clone() {
+        try {
+            return super.clone();
+        } catch (CloneNotSupportedException e) {
+            throw new InternalError();
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public <A extends ISPDataObject> A clone(A a) {
+        return (A) a.clone();
     }
 
     public ISysConfig getSysConfig() {

--- a/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs/diff/StaffOnlyFieldCorrection.scala
+++ b/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs/diff/StaffOnlyFieldCorrection.scala
@@ -1,0 +1,108 @@
+package edu.gemini.sp.vcs.diff
+
+import edu.gemini.pot.sp.version.LifespanId
+import edu.gemini.pot.sp.{ISPStaffOnlyFieldProtected, SPNodeKey}
+import edu.gemini.shared.util.VersionComparison.Newer
+import edu.gemini.sp.vcs.diff.MergeCorrection._
+import edu.gemini.spModel.core.SPProgramID
+import edu.gemini.spModel.data.ISPDataObject
+import edu.gemini.spModel.gemini.obscomp.SPProgram
+import edu.gemini.spModel.rich.pot.sp._
+
+import java.security.Permission
+
+import edu.gemini.util.security.permission.{VisitorPermission, StaffPermission}
+
+import scalaz._
+import Scalaz._
+
+/** Corrections required to reset any data object fields to which the user does
+  * not have permission.  Some data, for example time accounting information or
+  * private notes, may only be edited by staff members. If the user manages to
+  * edit these fields either via an OT bug or malicious editing of an exported
+  * program, they must be reset when synchronized with the remote database. */
+class StaffOnlyFieldCorrection(lifespanId: LifespanId, key: SPNodeKey, pid: SPProgramID, remote: SPNodeKey => Option[Modified]) extends CorrectionAction {
+
+  import StaffOnlyFieldCorrection._
+
+  private def resetFields(mp: MergePlan): MergePlan = {
+    def corrected(m: Modified, dob: StaffProtected, correct: StaffProtected => Unit): MergeNode =
+      m.copy(nv = m.nv.incr(lifespanId), dob = dob.copy <| correct)
+
+    def correctedNew(m: Modified, dob: StaffProtected): MergeNode =
+      if (dob.staffOnlyFieldsDefaulted()) m
+      else corrected(m, dob, _.resetStaffOnlyFieldsToDefaults())
+
+    def correctedExisting(m: Modified, dob: StaffProtected, existing: ISPDataObject): MergeNode =
+      if (dob.staffOnlyFieldsEqual(existing)) m
+      else corrected(m, dob, _.setStaffOnlyFieldsFrom(existing))
+
+    def correctedNode(mn: MergeNode): MergeNode =
+      mn match {
+        case m@Modified(k, nv, dob: StaffProtected, _) =>
+          remote(k).fold(correctedNew(m, dob)) { remoteMod =>
+            nv.compare(remoteMod.nv) match {
+              case Newer => correctedExisting(m, dob, remoteMod.dob)
+              case _     => mn
+            }
+          }
+
+        case _ => mn
+      }
+
+    mp.copy(update = mp.update.map(correctedNode))
+  }
+
+  def apply(mp: MergePlan, hasPermission: PermissionCheck): VcsAction[MergePlan] = {
+    // Regular staff permission is determined by program contact information. To
+    // prevent changing the contact and gaining staff permission we have to check
+    // that contacts aren't edited unless you have super-staff permission.
+    val contactsMatch = contact(mp.update.rootLabel) == remote(key).flatMap(contact)
+
+    canSetStaffFields(pid, contactsMatch, hasPermission).map { canSet =>
+      if (canSet) mp else resetFields(mp)
+    }
+  }
+}
+
+object StaffOnlyFieldCorrection {
+  type StaffProtected = ISPDataObject with ISPStaffOnlyFieldProtected
+
+  private def contact(mn: MergeNode): Option[String] = {
+    def contact(sp: SPProgram) = Option(sp.getContactPerson).map(_.trim.toLowerCase)
+
+    mn match {
+      case Modified(_, _, sp: SPProgram, _) => contact(sp)
+      case _                                => none
+    }
+  }
+
+  private def canSetStaffFields(pid: SPProgramID, contactsMatch: Boolean, hasPermission: PermissionCheck): VcsAction[Boolean] = {
+    def eitherPermission(p0: Permission, p1: Permission): VcsAction[Boolean] =
+      for {
+        b0 <- hasPermission(p0)
+        b1 <- hasPermission(p1)
+      } yield b0 || b1
+
+    val isStaff = eitherPermission(new StaffPermission(pid), new VisitorPermission(pid))
+    val isSuper = eitherPermission(new StaffPermission(), new VisitorPermission())
+
+    for {
+      sup   <- isSuper
+      staff <- isStaff
+    } yield sup || (contactsMatch && staff)
+  }
+
+  def apply(mc: MergeContext): StaffOnlyFieldCorrection = {
+    val remote = (key: SPNodeKey) => {
+      mc.remote.get(key).flatMap { t =>
+        t.rootLabel match {
+          case m: Modified => Some(m)
+          case _           => None
+        }
+      }
+    }
+
+    new StaffOnlyFieldCorrection(mc.local.prog.getLifespanId, mc.local.prog.key, mc.local.prog.getProgramID, remote)
+  }
+}

--- a/bundle/edu.gemini.sp.vcs/src/test/scala/edu/gemini/sp/vcs/diff/StaffOnlyFieldCorrectionSpec.scala
+++ b/bundle/edu.gemini.sp.vcs/src/test/scala/edu/gemini/sp/vcs/diff/StaffOnlyFieldCorrectionSpec.scala
@@ -1,0 +1,115 @@
+package edu.gemini.sp.vcs.diff
+
+import java.security.Principal
+
+import edu.gemini.spModel.obs.ObsQaState
+import edu.gemini.util.security.principal.{StaffPrincipal, VisitorPrincipal}
+import org.specs2.matcher.MatchResult
+
+import scalaz._
+
+class StaffOnlyFieldCorrectionSpec extends VcsSpecification {
+
+  import TestEnv._
+
+  def afterSync(env: TestEnv, p: Principal)(mr: => MatchResult[Any]): MatchResult[_] = {
+    expect(env.local.vcs(p).sync(Q1, DummyPeer)) {
+      case \/-(_) => mr
+    }
+  }
+
+  "staff only field correction" should {
+    "allow super-staff to change rollover status" in withVcs { env =>
+      env.local.rollover = true
+
+      (env.remote.rollover should beFalse) and afterSync(env, StaffPrincipal.Gemini) {
+        env.remote.rollover should beTrue
+      }
+    }
+
+    "allow visitor to change rollover status" in withVcs { env =>
+      env.local.rollover = true
+
+      (env.remote.rollover should beFalse) and afterSync(env, new VisitorPrincipal(Q1)) {
+        env.remote.rollover should beTrue
+      }
+    }
+
+    "allow normal staff to change rollover status" in withVcs { env =>
+      env.local.rollover = true
+
+      (env.remote.rollover should beFalse) and afterSync(env, StaffUserPrincipal) {
+        env.remote.rollover should beTrue
+      }
+    }
+
+    "not allow non-staff to change rollover status" in withVcs { env =>
+      env.local.rollover = true
+
+      afterSync(env, PiUserPrincipal) {
+        (env.local.rollover should beFalse) and (env.remote.rollover should beFalse)
+      }
+    }
+
+    "not allow non-staff to sneak a change to staff contact" in withVcs { env =>
+      env.local.rollover = true
+      env.local.contact  = PiEmail
+
+      afterSync(env, PiUserPrincipal) {
+        (env.local.rollover should beFalse) and
+          (env.remote.rollover should beFalse) and
+          (env.local.contact must_== StaffEmail) and
+          (env.remote.contact must_== StaffEmail)
+      }
+    }
+
+    "keep non-staff changes to non-protected fields" in withVcs { env =>
+      env.local.rollover  = true
+      env.local.progTitle = "The Plague"
+
+      afterSync(env, PiUserPrincipal) {
+        (env.remote.progTitle must_== "The Plague") and
+          (env.remote.rollover should beFalse) and
+          (env.local.rollover should beFalse)
+      }
+    }
+
+    "allow staff to change QA state" in withVcs { env =>
+      env.local.setQaState(ObsKey, ObsQaState.PASS)
+
+      afterSync(env, StaffUserPrincipal) {
+        env.remote.getQaState(ObsKey) must_== ObsQaState.PASS
+      }
+    }
+
+    "not allow non-staff to change QA state" in withVcs { env =>
+      env.local.setQaState(ObsKey, ObsQaState.PASS)
+
+      afterSync(env, PiUserPrincipal) {
+        (env.local.getQaState(ObsKey) must_== ObsQaState.UNDEFINED) and
+        (env.remote.getQaState(ObsKey) must_== ObsQaState.UNDEFINED)
+      }
+    }
+
+    "allow staff to create new observations with non-default QA state" in withVcs { env =>
+      val obsKey = env.local.addObservation()
+      env.local.setQaState(obsKey, ObsQaState.PASS)
+
+      afterSync(env, StaffUserPrincipal) {
+        env.remote.getQaState(obsKey) must_== ObsQaState.PASS
+      }
+    }
+
+    "not allow non-staff to create new observations with non-default QA state" in withVcs { env =>
+      val obsKey = env.local.addObservation()
+      env.local.setQaState(obsKey, ObsQaState.PASS)
+
+      afterSync(env, PiUserPrincipal) {
+        (env.local.getQaState(obsKey) must_== ObsQaState.UNDEFINED) and
+        (env.remote.getQaState(obsKey) must_== ObsQaState.UNDEFINED)
+      }
+    }
+  }
+
+
+}

--- a/bundle/edu.gemini.sp.vcs/src/test/scala/edu/gemini/sp/vcs/diff/VcsServerSpec.scala
+++ b/bundle/edu.gemini.sp.vcs/src/test/scala/edu/gemini/sp/vcs/diff/VcsServerSpec.scala
@@ -8,7 +8,7 @@ import edu.gemini.sp.vcs.diff.VcsAction._
 import edu.gemini.sp.vcs.diff.VcsFailure._
 import edu.gemini.spModel.core.SPProgramID
 import edu.gemini.spModel.gemini.obscomp.SPProgram
-import edu.gemini.util.security.principal.StaffPrincipal
+import edu.gemini.util.security.principal.{ProgramPrincipal, StaffPrincipal}
 
 import java.security.Principal
 
@@ -27,7 +27,7 @@ class VcsServerSpec extends VcsSpecification {
     }
 
     "fail if the user doesn't have access to the program" in withVcs { env =>
-      forbidden(env.local.server.read(Q1, progPrincipal(Q2)) { identity })
+      forbidden(env.local.server.read(Q1, Set(ProgramPrincipal(Q2))) { identity })
     }
 
     "handle any exceptions that happen" in withVcs { env =>
@@ -53,7 +53,7 @@ class VcsServerSpec extends VcsSpecification {
     }
 
     "fail if the user doesn't have access to the program" in withVcs { env =>
-      forbidden(dummyWrite(env, Q1, progPrincipal(Q2)))
+      forbidden(dummyWrite(env, Q1, Set(ProgramPrincipal(Q2))))
     }
 
     "handle any exceptions that happen in evaluate" in withVcs { env =>
@@ -115,7 +115,7 @@ class VcsServerSpec extends VcsSpecification {
 
   "add" should {
     "fail if the user doesn't have access to the program" in withVcs { env =>
-      val user    = progPrincipal(Q3)
+      val user    = Set(ProgramPrincipal(Q3): Principal)
       val newProg = env.local.newProgram(Q2)
       forbidden(env.local.server.add(newProg, user))
     }

--- a/bundle/edu.gemini.sp.vcs/src/test/scala/edu/gemini/sp/vcs/diff/VcsSpec.scala
+++ b/bundle/edu.gemini.sp.vcs/src/test/scala/edu/gemini/sp/vcs/diff/VcsSpec.scala
@@ -16,7 +16,7 @@ class VcsSpec extends VcsSpecification {
 
   "checkout" should {
     "fail if the indicated program doesn't exist remotely" in withVcs { env =>
-      notFound(env.local.staffVcs.checkout(Q2, DummyPeer), Q2)
+      notFound(env.local.superStaffVcs.checkout(Q2, DummyPeer), Q2)
     }
 
     "fail if the user doesn't have access to the program" in withVcs { env =>
@@ -29,7 +29,7 @@ class VcsSpec extends VcsSpecification {
       val remoteQ2 = env.remote.addNewProgram(Q2)
 
       // run checkout on the local peer
-      env.local.staffVcs.checkout(Q2, DummyPeer).unsafeRun
+      env.local.superStaffVcs.checkout(Q2, DummyPeer).unsafeRun
 
       val localQ2 = env.local.odb.lookupProgramByID(Q2)
 
@@ -39,7 +39,7 @@ class VcsSpec extends VcsSpecification {
 
   "add" should {
     "fail if the indicated program doesn't exist locally" in withVcs { env =>
-      notFound(env.local.staffVcs.add(Q2, DummyPeer), Q2)
+      notFound(env.local.superStaffVcs.add(Q2, DummyPeer), Q2)
     }
 
     "fail if the user doesn't have access to the program" in withVcs { env =>
@@ -52,7 +52,7 @@ class VcsSpec extends VcsSpecification {
       val localQ2 = env.local.addNewProgram(Q2)
 
       // run add to send it to the remote peer
-      env.local.staffVcs.add(Q2, DummyPeer).unsafeRun
+      env.local.superStaffVcs.add(Q2, DummyPeer).unsafeRun
 
       val remoteQ2 = env.remote.odb.lookupProgramByID(Q2)
 
@@ -63,12 +63,12 @@ class VcsSpec extends VcsSpecification {
   "pull" should {
     "fail if the indicated program doesn't exist locally" in withVcs { env =>
       env.remote.addNewProgram(Q2)
-      notFound(env.local.staffVcs.pull(Q2, DummyPeer), Q2)
+      notFound(env.local.superStaffVcs.pull(Q2, DummyPeer), Q2)
     }
 
     "fail if the indicated program doesn't exist remotely" in withVcs { env =>
       env.local.addNewProgram(Q2)
-      notFound(env.local.staffVcs.pull(Q2, DummyPeer), Q2)
+      notFound(env.local.superStaffVcs.pull(Q2, DummyPeer), Q2)
     }
 
     "fail if the user doesn't have access to the program" in withVcs { env =>
@@ -78,11 +78,11 @@ class VcsSpec extends VcsSpecification {
     "fail if the indicated program has different keys locally vs remotely" in withVcs { env =>
       env.local.addNewProgram(Q2)
       env.remote.addNewProgram(Q2)
-      idClash(env.local.staffVcs.pull(Q2, DummyPeer), Q2)
+      idClash(env.local.superStaffVcs.pull(Q2, DummyPeer), Q2)
     }
 
     "do nothing if the local version is the same" in withVcs { env =>
-      expect(env.local.staffVcs.pull(Q1, DummyPeer)) {
+      expect(env.local.superStaffVcs.pull(Q1, DummyPeer)) {
         case \/-(false) => ok("")
       }
     }
@@ -90,7 +90,7 @@ class VcsSpec extends VcsSpecification {
     "do nothing if the local version is newer" in withVcs { env =>
       env.local.progTitle = "The Myth of Sisyphus"
 
-      expect(env.local.staffVcs.pull(Q1, DummyPeer)) {
+      expect(env.local.superStaffVcs.pull(Q1, DummyPeer)) {
         case \/-(false) => ok("")
       } and (env.local.progTitle must_== "The Myth of Sisyphus")
     }
@@ -98,7 +98,7 @@ class VcsSpec extends VcsSpecification {
     "merge the updates if the remote version is newer" in withVcs { env =>
       env.remote.progTitle = "The Myth of Sisyphus"
 
-      expect(env.local.staffVcs.pull(Q1, DummyPeer)) {
+      expect(env.local.superStaffVcs.pull(Q1, DummyPeer)) {
         case \/-(true) => ok("")
       } and (env.local.progTitle must_== "The Myth of Sisyphus")
     }
@@ -107,12 +107,12 @@ class VcsSpec extends VcsSpecification {
   "push" should {
     "fail if the indicated program doesn't exist locally" in withVcs { env =>
       env.remote.addNewProgram(Q2)
-      notFound(env.local.staffVcs.push(Q2, DummyPeer), Q2)
+      notFound(env.local.superStaffVcs.push(Q2, DummyPeer), Q2)
     }
 
     "fail if the indicated program doesn't exist remotely" in withVcs { env =>
       env.local.addNewProgram(Q2)
-      notFound(env.local.staffVcs.push(Q2, DummyPeer), Q2)
+      notFound(env.local.superStaffVcs.push(Q2, DummyPeer), Q2)
     }
 
     "fail if the user doesn't have access to the program" in withVcs { env =>
@@ -122,11 +122,11 @@ class VcsSpec extends VcsSpecification {
     "fail if the indicated program has different keys locally vs remotely" in withVcs { env =>
       env.local.addNewProgram(Q2)
       env.remote.addNewProgram(Q2)
-      idClash(env.local.staffVcs.push(Q2, DummyPeer), Q2)
+      idClash(env.local.superStaffVcs.push(Q2, DummyPeer), Q2)
     }
 
     "do nothing if the local version is the same" in withVcs { env =>
-      expect(env.local.staffVcs.push(Q1, DummyPeer)) {
+      expect(env.local.superStaffVcs.push(Q1, DummyPeer)) {
         case \/-(false) => ok("")
       }
     }
@@ -134,7 +134,7 @@ class VcsSpec extends VcsSpecification {
     "fail with NeedsUpdate if the local version is older" in withVcs { env =>
       env.remote.progTitle = "The Myth of Sisyphus"
 
-      expect(env.local.staffVcs.push(Q1, DummyPeer)) {
+      expect(env.local.superStaffVcs.push(Q1, DummyPeer)) {
         case -\/(NeedsUpdate) => ok("")
       } and (env.local.progTitle must_== Title)
     }
@@ -142,7 +142,7 @@ class VcsSpec extends VcsSpecification {
     "merge the updates if the local version is newer" in withVcs { env =>
       env.local.progTitle = "The Myth of Sisyphus"
 
-      expect(env.local.staffVcs.push(Q1, DummyPeer)) {
+      expect(env.local.superStaffVcs.push(Q1, DummyPeer)) {
         case \/-(true) => ok("")
       } and (env.remote.progTitle must_== "The Myth of Sisyphus")
     }
@@ -154,12 +154,12 @@ class VcsSpec extends VcsSpecification {
     name should {
       "fail if the indicated program doesn't exist locally" in withVcs { env =>
         env.remote.addNewProgram(Q2)
-        notFound(syncMethod(env.local.staffVcs, Q2), Q2)
+        notFound(syncMethod(env.local.superStaffVcs, Q2), Q2)
       }
 
       "fail if the indicated program doesn't exist remotely" in withVcs { env =>
         env.local.addNewProgram(Q2)
-        notFound(syncMethod(env.local.staffVcs, Q2), Q2)
+        notFound(syncMethod(env.local.superStaffVcs, Q2), Q2)
       }
 
       "fail if the user doesn't have access to the program" in withVcs { env =>
@@ -169,11 +169,11 @@ class VcsSpec extends VcsSpecification {
       "fail if the indicated program has different keys locally vs remotely" in withVcs { env =>
         env.local.addNewProgram(Q2)
         env.remote.addNewProgram(Q2)
-        idClash(syncMethod(env.local.staffVcs, Q2), Q2)
+        idClash(syncMethod(env.local.superStaffVcs, Q2), Q2)
       }
 
       "do nothing if both versions are the same" in withVcs { env =>
-        expect(syncMethod(env.local.staffVcs, Q1)) {
+        expect(syncMethod(env.local.superStaffVcs, Q1)) {
           case \/-(ProgramLocation.Neither) => ok("")
         }
       }
@@ -181,7 +181,7 @@ class VcsSpec extends VcsSpecification {
       "merge the remote updates if the remote version is newer" in withVcs { env =>
         env.remote.progTitle = "The Myth of Sisyphus"
 
-        expect(syncMethod(env.local.staffVcs, Q1)) {
+        expect(syncMethod(env.local.superStaffVcs, Q1)) {
           case \/-(ProgramLocation.LocalOnly) => ok("")
         } and (env.local.progTitle must_== "The Myth of Sisyphus")
       }
@@ -189,7 +189,7 @@ class VcsSpec extends VcsSpecification {
       "send the local updates if the local version is newer" in withVcs { env =>
         env.local.progTitle = "The Myth of Sisyphus"
 
-        expect(syncMethod(env.local.staffVcs, Q1)) {
+        expect(syncMethod(env.local.superStaffVcs, Q1)) {
           case \/-(ProgramLocation.RemoteOnly) => ok("")
         } and (env.remote.progTitle must_== "The Myth of Sisyphus")
       }
@@ -201,7 +201,7 @@ class VcsSpec extends VcsSpecification {
         val note = env.remote.odb.getFactory.createObsComponent(env.remote.prog, SPNote.SP_TYPE, null)
         env.remote.prog.addObsComponent(note)
 
-        expect(syncMethod(env.local.staffVcs, Q1)) {
+        expect(syncMethod(env.local.superStaffVcs, Q1)) {
           case \/-(ProgramLocation.Both) => ok("")
         } and (env.remote.prog.getGroups.get(0).getNodeKey must_== group.getNodeKey) and
           (env.local.prog.getObsComponents.get(0).getNodeKey must_== note.getNodeKey)

--- a/bundle/edu.gemini.spModel.core/src/main/scala/edu/gemini/spModel/core/Magnitude.scala
+++ b/bundle/edu.gemini.spModel.core/src/main/scala/edu/gemini/spModel/core/Magnitude.scala
@@ -29,6 +29,16 @@ object Magnitude {
   implicit val MagnitudeOrdering: scala.math.Ordering[Magnitude] =
     scala.math.Ordering.by(m => (m.system.name, m.band.name, m.value, m.error))
 
+  // comparison on Option[Magnitude] that reverses the way that None is treated, i.e. None is always > Some(Magnitude).
+  implicit val MagnitudeOptionOrdering: scala.math.Ordering[Option[Magnitude]] = new scala.math.Ordering[Option[Magnitude]] {
+    override def compare(x: Option[Magnitude], y: Option[Magnitude]): Int = (x,y) match {
+      case (Some(m1), Some(m2)) => MagnitudeOrdering.compare(m1, m2)
+      case (None, None)         => 0
+      case (_, None)            => -1
+      case (None, _)            => 1
+    }
+  }
+
   /** @group Typeclass Instances */
   implicit val equals = scalaz.Equal.equalA[Magnitude]
 

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/editor/OtItemEditor.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/editor/OtItemEditor.java
@@ -10,6 +10,7 @@ import edu.gemini.pot.sp.*;
 import edu.gemini.shared.gui.calendar.JCalendarPopup;
 import edu.gemini.spModel.data.ISPDataObject;
 import edu.gemini.spModel.gemini.obscomp.SPProgram;
+import edu.gemini.spModel.gemini.obscomp.SPSiteQuality;
 import edu.gemini.spModel.obscomp.SPInstObsComp;
 import edu.gemini.spModel.target.env.TargetEnvironment;
 import edu.gemini.spModel.target.obsComp.TargetObsComp;
@@ -273,6 +274,16 @@ public abstract class OtItemEditor<N extends ISPNode, T extends ISPDataObject> {
             for (ISPObsComponent c : o.getObsComponents())
                 if (c.getType() == SPComponentType.TELESCOPE_TARGETENV)
                     return c;
+        }
+        return null;
+    }
+
+    public SPSiteQuality getContextSiteQuality() {
+        final ISPObservation o = getContextObservation();
+        if (o != null) {
+            for (ISPObsComponent c : o.getObsComponents())
+                if (c.getType() == SPComponentType.SCHEDULING_CONDITIONS)
+                    return (SPSiteQuality) c.getDataObject();
         }
         return null;
     }

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/flamingos2/Flamingos2_SciAreaFeature.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/flamingos2/Flamingos2_SciAreaFeature.java
@@ -4,11 +4,14 @@
 
 package jsky.app.ot.gemini.flamingos2;
 
-import diva.util.java2d.Polygon2D;
+import edu.gemini.shared.util.immutable.ApplyOp;
+import edu.gemini.shared.util.immutable.ImList;
 import edu.gemini.spModel.data.AbstractDataObject;
+import edu.gemini.spModel.gemini.flamingos2.F2ScienceAreaGeometry;
 import edu.gemini.spModel.gemini.flamingos2.Flamingos2;
 import edu.gemini.spModel.gemini.flamingos2.Flamingos2.FPUnit;
 import edu.gemini.spModel.gemini.gems.Gems;
+import edu.gemini.spModel.inst.FeatureGeometry$;
 import edu.gemini.spModel.obs.context.ObsContext;
 import edu.gemini.spModel.util.Angle;
 import jsky.app.ot.gemini.inst.SciAreaFeatureBase;
@@ -21,8 +24,6 @@ import java.awt.Graphics;
 import java.awt.Graphics2D;
 import java.awt.Shape;
 import java.awt.geom.AffineTransform;
-import java.awt.geom.Area;
-import java.awt.geom.Ellipse2D;
 import java.awt.geom.Point2D;
 
 
@@ -52,101 +53,23 @@ public class Flamingos2_SciAreaFeature  extends SciAreaFeatureBase {
     public Flamingos2_SciAreaFeature() {
     }
 
-
-    /**
-     * Add the imaging FOV to the list of figures to display.
-     * @param plateScale plate scale in arcsec/mm
-     */
-    private void _addImagingFOV(double plateScale) {
-        double size = Flamingos2.IMAGING_FOV_SIZE * plateScale * _pixelsPerArcsec;
-        double radius = size/2.;
-        Ellipse2D.Double fig = new Ellipse2D.Double(_baseScreenPos.x - radius,
-                                                    _baseScreenPos.y - radius,
-                                                    size, size);
-        _figureList.add(fig);
-    }
-
-    /**
-     * Add the MOS field of view to the list of figures to display.
-     * @param plateScale plate scale in arcsec/mm
-     */
-    private void _addMOS_FOV(double plateScale) {
-
-        // Make the rectangle and circle and then take the intersection
-        double width = Flamingos2.MOS_FOV_WIDTH * plateScale * _pixelsPerArcsec;
-        double height = Flamingos2.IMAGING_FOV_SIZE * plateScale * _pixelsPerArcsec;
-
-        double radius = height /2.;
-        Ellipse2D.Double circle = new Ellipse2D.Double(_baseScreenPos.x - radius,
-                                                       _baseScreenPos.y - radius,
-                                                       height, height);
-
-        double x = _baseScreenPos.x - (width / 2);
-        double y = _baseScreenPos.y - radius;
-        Polygon2D.Double rect = new Polygon2D.Double(x, y);
-        rect.lineTo(x + width, y);
-        rect.lineTo(x + width, y + height);
-        rect.lineTo(x, y + height);
-
-        // rotate by position angle
-        rect.transform(_posAngleTrans);
-
-        // take the intersection
-        Area area = new Area(circle);
-        area.intersect(new Area(rect));
-
-        _figureList.add(area);
-    }
-
-    /**
-     * Add the long slit field of view to the list of figures to display.
-     * @param plateScale plate scale in arcsec/mm
-     */
-    private void _addLongSlitFOV(double plateScale) {
-        double slitWidth = _sciArea.getWidth();
-        double slitHeight = Flamingos2.LONG_SLIT_FOV_HEIGHT * plateScale * _pixelsPerArcsec;
-
-        double slitSouth = Flamingos2.LONG_SLIT_FOV_SOUTH_POS * plateScale * _pixelsPerArcsec;
-
-        double x = _baseScreenPos.x - (slitWidth / 2);
-        double y = _baseScreenPos.y + slitSouth;
-
-        Polygon2D.Double slit = new Polygon2D.Double(x, y);
-        slit.lineTo(x + slitWidth, y);
-        slit.lineTo(x + slitWidth, y - slitHeight);
-        slit.lineTo(x, y - slitHeight);
-
-        // rotate by position angle
-        slit.transform(_posAngleTrans);
-
-        _figureList.add(slit);
-    }
-
     /**
      * Update the list of FOV figures to draw.
      */
     protected void _updateFigureList() {
         _figureList.clear();
-
-        // OT-540:
-        // There should be different FOV drawings for imaging, MOS, longslit,
-        // MCAO imaging, MCAO MOS, and the OIWFS (for both non-AO and MCAO feeds).
-        // (OIWFS is handled elsewhere)
-        Flamingos2 inst = getFlamingos2();
+        final Flamingos2 inst = getFlamingos2();
         if (inst != null) {
-            double plateScale = inst.getLyotWheel().getPlateScale();
-            Flamingos2.FPUnit fpu = inst.getFpu();
-            switch (fpu) {
-                case FPU_NONE:
-                    _addImagingFOV(plateScale);
-                    break;
-                case CUSTOM_MASK:
-                    _addMOS_FOV(plateScale);
-                    break;
-                default:
-                    if (fpu.isLongslit()) _addLongSlitFOV(plateScale);
-                    break;
-            }
+            final ObsContext ctx = _iw.getMinimalObsContext().getOrNull();
+            final ImList<Shape> shape = inst.getVignettableScienceArea().geometryAsJava();
+            shape.foreach(new ApplyOp<Shape>() {
+                @Override
+                public void apply(final Shape s) {
+                    final Shape s2 = FeatureGeometry$.MODULE$.transformScienceAreaForContext(s, ctx);
+                    final Shape s3 = FeatureGeometry$.MODULE$.transformScienceAreaForScreen(s2, _pixelsPerArcsec, ctx, _baseScreenPos);
+                    _figureList.add(s3);
+                }
+            });
         }
     }
 
@@ -158,30 +81,28 @@ public class Flamingos2_SciAreaFeature  extends SciAreaFeatureBase {
      * Overriden to take into account fov rotation from config file
      */
     @Override
-    protected boolean _calc(TpeImageInfo tii)  {
-        Flamingos2 inst = getFlamingos2();
+    protected boolean _calc(final TpeImageInfo tii)  {
+        final Flamingos2 inst = getFlamingos2();
         if (inst == null) return false;
 
         _sciArea.update(inst, tii);
         _baseScreenPos = tii.getBaseScreenPos();
         _sciAreaPD = _sciArea.getPolygonDAt(_baseScreenPos.x, _baseScreenPos.y);
         _pixelsPerArcsec = tii.getPixelsPerArcsec();
-        double posAngle = tii.getCorrectedPosAngleRadians();
+        final double posAngle = tii.getCorrectedPosAngleRadians();
         _posAngleTrans.setToIdentity();
         _posAngleTrans.rotate(-posAngle, _baseScreenPos.x, _baseScreenPos.y);
 
 
-        ObsContext ctx = _iw.getObsContext().getOrNull();
+        final ObsContext ctx = _iw.getObsContext().getOrNull();
         if (ctx != null) {
-            AbstractDataObject aoComp = ctx.getAOComponent().getOrNull();
+            final AbstractDataObject aoComp = ctx.getAOComponent().getOrNull();
             if (aoComp != null) {
                 _fovRotation = inst.getRotationConfig(aoComp.getNarrowType().equals(Gems.SP_TYPE.narrowType)).toRadians().getMagnitude();
             } else {
                 _fovRotation = inst.getRotationConfig(false).toRadians().getMagnitude();
             }
         } else {
-// RCN: actually this is ok; it happens in template obs
-//            System.out.println("No ObsContext!!!");
             _fovRotation = inst.getRotationConfig(false).toRadians().getMagnitude();
         }
 
@@ -190,12 +111,12 @@ public class Flamingos2_SciAreaFeature  extends SciAreaFeatureBase {
 
         // Init the _tickMarkPD
         if (_tickMarkPD == null) {
-            double[] xpoints = new double[4];
-            double[] ypoints = new double[4];
+            final double[] xpoints = new double[4];
+            final double[] ypoints = new double[4];
             _tickMarkPD = new PolygonD(xpoints, ypoints, 4);
         }
 
-        Point2D.Double tickOffset = _getTickMarkOffset();
+        final Point2D.Double tickOffset = _getTickMarkOffset();
 
         _tickMarkPD.xpoints[0] = tickOffset.x;
         _tickMarkPD.ypoints[0] = tickOffset.y - MARKER_SIZE * 2;
@@ -209,9 +130,8 @@ public class Flamingos2_SciAreaFeature  extends SciAreaFeatureBase {
         _tickMarkPD.xpoints[3] = _tickMarkPD.xpoints[0];
         _tickMarkPD.ypoints[3] = _tickMarkPD.ypoints[0];
 
-        //_iw.skyRotate(_tickMarkPD);
-        //rotate tick mark
-        double angle = tii.getCorrectedPosAngleRadians() + _fovRotation;
+        // Rotate tick mark
+        final double angle = tii.getCorrectedPosAngleRadians() + _fovRotation;
 
         ScreenMath.rotateRadians(_tickMarkPD, angle, _baseScreenPos.x, _baseScreenPos.y);
         _updateFigureList();
@@ -222,15 +142,17 @@ public class Flamingos2_SciAreaFeature  extends SciAreaFeatureBase {
      * Draw the feature.
      */
     @Override
-    public void draw(Graphics g, TpeImageInfo tii) {
-        Graphics2D g2d = (Graphics2D) g;
+    public void draw(final Graphics g, final TpeImageInfo tii) {
+        final Graphics2D g2d = (Graphics2D) g;
 
         if (!_calc(tii)) return;
 
         g2d.setColor(FOV_COLOR);
 
-        // draw the FOV
-        for (Shape shape : _figureList) g2d.draw(shape);
+        // Draw the FOV
+        for (final Shape shape : _figureList)
+            g2d.draw(shape);
+
         drawDragItem(g2d);
     }
     /**
@@ -238,7 +160,7 @@ public class Flamingos2_SciAreaFeature  extends SciAreaFeatureBase {
       * Overridden to take into account fov rotation from config file.
       */
     @Override
-     public void drag(TpeMouseEvent tme) {
+     public void drag(final TpeMouseEvent tme) {
          if (_dragX == tme.xWidget && _dragY == tme.yWidget) {
              _iw.repaint();
              return;
@@ -248,8 +170,8 @@ public class Flamingos2_SciAreaFeature  extends SciAreaFeatureBase {
          _dragX = tme.xWidget;
          _dragY = tme.yWidget;
 
-         double radians = _dragObject.getAngle(_dragX, _dragY) * _tii.flipRA() + _tii.getTheta();
-         double degrees = Math.round(Angle.radiansToDegrees(radians-_fovRotation));
+         final double radians = _dragObject.getAngle(_dragX, _dragY) * _tii.flipRA() + _tii.getTheta();
+         final double degrees = Math.round(Angle.radiansToDegrees(radians-_fovRotation));
         _iw.setPosAngle(degrees);
         _iw.repaint();
      }
@@ -258,7 +180,7 @@ public class Flamingos2_SciAreaFeature  extends SciAreaFeatureBase {
      * Draw the science area at the given x,y (screen coordinate) offset position.
      */
     @Override
-    public void drawAtOffsetPos(Graphics g, TpeImageInfo tii, double x, double y) {
+    public void drawAtOffsetPos(final Graphics g, final TpeImageInfo tii, final double x, final double y) {
         if (!_calc(tii)) return;
 
         final Graphics2D g2d = (Graphics2D) g;
@@ -266,7 +188,7 @@ public class Flamingos2_SciAreaFeature  extends SciAreaFeatureBase {
             final AffineTransform saveAT = g2d.getTransform();
             try {
                 g2d.translate(x - _baseScreenPos.x, y - _baseScreenPos.y);
-                for (Shape shape : _figureList) {
+                for (final Shape shape : _figureList) {
                     g2d.draw(shape);
                 }
             } finally {
@@ -285,11 +207,11 @@ public class Flamingos2_SciAreaFeature  extends SciAreaFeatureBase {
         final Flamingos2 inst = getFlamingos2();
         final Point2D.Double offset;
         if (inst != null) {
-            FPUnit fpu = inst.getFpu();
+            final FPUnit fpu = inst.getFpu();
 
-            double plateScale = inst.getLyotWheel().getPlateScale();
+            final double plateScale = inst.getLyotWheel().getPlateScale();
             if (fpu.isLongslit()) {
-                double slitNorth = Flamingos2.LONG_SLIT_FOV_NORTH_POS * plateScale * _pixelsPerArcsec;
+                final double slitNorth = F2ScienceAreaGeometry.LongSlitFOVNorthPos() * plateScale * _pixelsPerArcsec;
                 offset = new Point2D.Double(_baseScreenPos.x,
                                             _baseScreenPos.y - slitNorth);
 

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/gmos/GMOS_SciAreaFeature.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/gmos/GMOS_SciAreaFeature.java
@@ -99,7 +99,7 @@ public class GMOS_SciAreaFeature extends SciAreaFeatureBase {
         if (instGMOS != null) {
             final ObsContext ctx = _iw.getMinimalObsContext().getOrNull();
             if (ctx != null) {
-                final ImList<Shape> shape = new GmosScienceAreaGeometry().geometryAsJava(instGMOS);
+                final ImList<Shape> shape = instGMOS.getVignettableScienceArea().geometryAsJava();
                 shape.foreach(new ApplyOp<Shape>() {
                     @Override
                     public void apply(final Shape s) {

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcTable.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcTable.scala
@@ -9,7 +9,7 @@ import edu.gemini.pot.sp.SPComponentType
 import edu.gemini.spModel.config.ConfigBridge
 import edu.gemini.spModel.config.map.ConfigValMapInstances
 import edu.gemini.spModel.config2.{ConfigSequence, ItemKey}
-import edu.gemini.spModel.core.Site
+import edu.gemini.spModel.core.{Peer, Site}
 import edu.gemini.spModel.gemini.gmos.GmosCommonType
 import jsky.app.ot.OT
 import jsky.app.ot.userprefs.observer.ObservingPeer
@@ -18,6 +18,8 @@ import jsky.app.ot.util.OtColor
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 import scala.swing.{Swing, Table}
+
+import scalaz.Scalaz._
 
 /**
  * A table to display ITC calculation results to users.
@@ -64,39 +66,39 @@ trait ItcTable extends Table {
     ConfigBridge.extractSequence(_, null, ConfigValMapInstances.IDENTITY_MAP, true)
   }
 
-  protected def callService(c: ItcUniqueConfig): Future[ItcService.Result] = {
+  protected def calculateSpectroscopy(c: ItcUniqueConfig, peer: Peer): Future[ItcService.Result] =
+    Future {
+      List("Not Implemented Yet").fail
+    }
 
-    ObservingPeer.get.map { peer =>
-      val port = owner.getContextIssPort
-      //val wfs  = ??? TODO
-      val src  = new SourceDefinition(PointSource(20.0, BrightnessUnit.MAG), LibraryStar("A0V"), WavebandDefinition.R, 0.0)
-      val obs  = new ObservationDetails(ImagingSN(c.count, c.singleExposureTime, 1.0), AutoAperture(5.0))
-      val tele = new TelescopeDetails(TelescopeDetails.Coating.SILVER, port, Wfs.OIWFS)
+  protected def calculateImaging(c: ItcUniqueConfig, peer: Peer): Future[ItcService.Result] = {
+    val port = owner.getContextIssPort
+    //val wfs  = ??? TODO
+    val src  = new SourceDefinition(PointSource(20.0, BrightnessUnit.MAG), LibraryStar("A0V"), WavebandDefinition.R, 0.0)
+    val obs  = new ObservationDetails(ImagingSN(c.count, c.singleExposureTime, 1.0), AutoAperture(5.0))
+    val tele = new TelescopeDetails(TelescopeDetails.Coating.SILVER, port, Wfs.OIWFS)
 
-      val qual = owner.getContextSiteQuality
-      val cond = new ObservingConditions(qual.getImageQuality, qual.getCloudCover, qual.getWaterVapor, qual.getSkyBackground, 1.5)
+    val qual = owner.getContextSiteQuality
+    val cond = new ObservingConditions(qual.getImageQuality, qual.getCloudCover, qual.getWaterVapor, qual.getSkyBackground, 1.5)
 
-      // get the instrument configuration
-      val filter    = c.config.getItemValue(new ItemKey("instrument:filter")).asInstanceOf[GmosCommonType.Filter]
-      val grating   = c.config.getItemValue(new ItemKey("instrument:disperser")).asInstanceOf[GmosCommonType.Disperser]
-      val wavelen   = 500.0 // ??? TODO
-      val fpmask    = c.config.getItemValue(new ItemKey("instrument:fpu")).asInstanceOf[GmosCommonType.FPUnit]
-      val spatBin   = c.config.getItemValue(new ItemKey("instrument:ccdXBinning")).asInstanceOf[GmosCommonType.Binning]
-      val specBin   = c.config.getItemValue(new ItemKey("instrument:ccdYBinning")).asInstanceOf[GmosCommonType.Binning]
-      val ccdType   = c.config.getItemValue(new ItemKey("instrument:detectorManufacturer")).asInstanceOf[GmosCommonType.DetectorManufacturer]
-      val ifuMethod = None
-      val site      = if (c.config.getItemValue(new ItemKey("instrument:instrument")).equals("GMOS-N")) Site.GN else Site.GS
-      val ins       = GmosParameters(filter, grating, wavelen, fpmask, spatBin.getValue, specBin.getValue, ifuMethod, ccdType, site)
+    // get the instrument configuration
+    val filter    = c.config.getItemValue(new ItemKey("instrument:filter")).asInstanceOf[GmosCommonType.Filter]
+    val grating   = c.config.getItemValue(new ItemKey("instrument:disperser")).asInstanceOf[GmosCommonType.Disperser]
+    val wavelen   = 500.0 // ??? TODO
+    val fpmask    = c.config.getItemValue(new ItemKey("instrument:fpu")).asInstanceOf[GmosCommonType.FPUnit]
+    val spatBin   = c.config.getItemValue(new ItemKey("instrument:ccdXBinning")).asInstanceOf[GmosCommonType.Binning]
+    val specBin   = c.config.getItemValue(new ItemKey("instrument:ccdYBinning")).asInstanceOf[GmosCommonType.Binning]
+    val ccdType   = c.config.getItemValue(new ItemKey("instrument:detectorManufacturer")).asInstanceOf[GmosCommonType.DetectorManufacturer]
+    val ifuMethod = None
+    val site      = if (c.config.getItemValue(new ItemKey("instrument:instrument")).equals("GMOS-N")) Site.GN else Site.GS
+    val ins       = GmosParameters(filter, grating, wavelen, fpmask, spatBin.getValue, specBin.getValue, ifuMethod, ccdType, site)
 
-      // Do the service call
-      ItcService.calculate(OT.getKeyChain, peer, src, obs, cond, tele, ins).
-      // whenever service call is finished notify table to update its contents
-      andThen {
-        case _ => Swing.onEDT(this.peer.getModel.asInstanceOf[AbstractTableModel].fireTableDataChanged())
-      }
-
-    }.get  // TODO: what to do if no peer is present?
-
+    // Do the service call
+    ItcService.calculate(OT.getKeyChain, peer, src, obs, cond, tele, ins).
+    // whenever service call is finished notify table to update its contents
+    andThen {
+      case _ => Swing.onEDT(this.peer.getModel.asInstanceOf[AbstractTableModel].fireTableDataChanged())
+    }
   }
 
 }
@@ -104,27 +106,32 @@ trait ItcTable extends Table {
 class ItcImagingTable(val owner: EdIteratorFolder) extends ItcTable {
   private val emptyTable: ItcImagingTableModel = new ItcGenericImagingTableModel(Seq(), Seq(), Seq())
 
-  /**
-   * Creates a new table model for the current context (instrument) and config sequence.
-   * Note that GMOS has a different table model with separate columns for its three CCDs.
-   */
+  /** Creates a new table model for the current context (instrument) and config sequence.
+    * Note that GMOS has a different table model with separate columns for its three CCDs. */
   def tableModel(keys: Seq[ItemKey], seq: ConfigSequence): ItcImagingTableModel = {
-    val uniqConfigs = ItcUniqueConfig.imagingConfigs(seq)
-    val results     = uniqConfigs.map(callService)
-    Option(owner.getContextInstrument).fold(emptyTable) {
-      _.getType match {
-        case SPComponentType.INSTRUMENT_GMOS      => new ItcGmosImagingTableModel(keys, uniqConfigs, results)
-        case SPComponentType.INSTRUMENT_GMOSSOUTH => new ItcGmosImagingTableModel(keys, uniqConfigs, results)
-        case _                                    => new ItcGenericImagingTableModel(keys, uniqConfigs, results)
+    ObservingPeer.getOrPrompt.fold(emptyTable) { peer =>
+      val uniqConfigs = ItcUniqueConfig.imagingConfigs(seq)
+      val results     = uniqConfigs.map(calculateImaging(_, peer))
+      Option(owner.getContextInstrument).map(_.getType) match {
+        case None                                       => emptyTable // just in case; context instrument should always be present (?)
+        case Some(SPComponentType.INSTRUMENT_GMOS)      => new ItcGmosImagingTableModel(keys, uniqConfigs, results)
+        case Some(SPComponentType.INSTRUMENT_GMOSSOUTH) => new ItcGmosImagingTableModel(keys, uniqConfigs, results)
+        case _                                          => new ItcGenericImagingTableModel(keys, uniqConfigs, results)
       }
     }
   }
 }
 
 class ItcSpectroscopyTable(val owner: EdIteratorFolder) extends ItcTable {
+  private val emptyTable: ItcGenericSpectroscopyTableModel = new ItcGenericSpectroscopyTableModel(Seq(), Seq(), Seq())
 
   /** Creates a new table model for the current context and config sequence. */
-  def tableModel(keys: Seq[ItemKey], seq: ConfigSequence) = new ItcGenericSpectroscopyTableModel(keys, ItcUniqueConfig.spectroscopyConfigs(seq), Seq())
+  def tableModel(keys: Seq[ItemKey], seq: ConfigSequence) =
+    ObservingPeer.getOrPrompt.fold(emptyTable) { peer =>
+      val uniqueConfigs = ItcUniqueConfig.spectroscopyConfigs(seq)
+      val results       = uniqueConfigs.map(calculateSpectroscopy(_, peer))
+      new ItcGenericSpectroscopyTableModel(keys, uniqueConfigs, results)
+  }
 
 }
 

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcTable.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcTable.scala
@@ -1,14 +1,23 @@
 package jsky.app.ot.editor.seq
 
 import java.awt.Color
+import javax.swing.table.AbstractTableModel
 
+import edu.gemini.itc.shared.TelescopeDetails.Wfs
+import edu.gemini.itc.shared._
 import edu.gemini.pot.sp.SPComponentType
 import edu.gemini.spModel.config.ConfigBridge
 import edu.gemini.spModel.config.map.ConfigValMapInstances
 import edu.gemini.spModel.config2.{ConfigSequence, ItemKey}
+import edu.gemini.spModel.core.Site
+import edu.gemini.spModel.gemini.gmos.GmosCommonType
+import jsky.app.ot.OT
+import jsky.app.ot.userprefs.observer.ObservingPeer
 import jsky.app.ot.util.OtColor
 
-import scala.swing.Table
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+import scala.swing.{Swing, Table}
 
 /**
  * A table to display ITC calculation results to users.
@@ -55,21 +64,59 @@ trait ItcTable extends Table {
     ConfigBridge.extractSequence(_, null, ConfigValMapInstances.IDENTITY_MAP, true)
   }
 
+  protected def callService(c: ItcUniqueConfig): Future[ItcService.Result] = {
+
+    ObservingPeer.get.map { peer =>
+      val port = owner.getContextIssPort
+      //val wfs  = ??? TODO
+      val src  = new SourceDefinition(PointSource(20.0, BrightnessUnit.MAG), LibraryStar("A0V"), WavebandDefinition.R, 0.0)
+      val obs  = new ObservationDetails(ImagingSN(c.count, c.singleExposureTime, 1.0), AutoAperture(5.0))
+      val tele = new TelescopeDetails(TelescopeDetails.Coating.SILVER, port, Wfs.OIWFS)
+
+      val qual = owner.getContextSiteQuality
+      val cond = new ObservingConditions(qual.getImageQuality, qual.getCloudCover, qual.getWaterVapor, qual.getSkyBackground, 1.5)
+
+      // get the instrument configuration
+      val filter    = c.config.getItemValue(new ItemKey("instrument:filter")).asInstanceOf[GmosCommonType.Filter]
+      val grating   = c.config.getItemValue(new ItemKey("instrument:disperser")).asInstanceOf[GmosCommonType.Disperser]
+      val wavelen   = 500.0 // ??? TODO
+      val fpmask    = c.config.getItemValue(new ItemKey("instrument:fpu")).asInstanceOf[GmosCommonType.FPUnit]
+      val spatBin   = c.config.getItemValue(new ItemKey("instrument:ccdXBinning")).asInstanceOf[GmosCommonType.Binning]
+      val specBin   = c.config.getItemValue(new ItemKey("instrument:ccdYBinning")).asInstanceOf[GmosCommonType.Binning]
+      val ccdType   = c.config.getItemValue(new ItemKey("instrument:detectorManufacturer")).asInstanceOf[GmosCommonType.DetectorManufacturer]
+      val ifuMethod = None
+      val site      = if (c.config.getItemValue(new ItemKey("instrument:instrument")).equals("GMOS-N")) Site.GN else Site.GS
+      val ins       = GmosParameters(filter, grating, wavelen, fpmask, spatBin.getValue, specBin.getValue, ifuMethod, ccdType, site)
+
+      // Do the service call
+      ItcService.calculate(OT.getKeyChain, peer, src, obs, cond, tele, ins).
+      // whenever service call is finished notify table to update its contents
+      andThen {
+        case _ => Swing.onEDT(this.peer.getModel.asInstanceOf[AbstractTableModel].fireTableDataChanged())
+      }
+
+    }.get  // TODO: what to do if no peer is present?
+
+  }
+
 }
 
 class ItcImagingTable(val owner: EdIteratorFolder) extends ItcTable {
-  private val emptyTable: ItcImagingTableModel = new ItcGenericImagingTableModel(Seq(), Seq())
+  private val emptyTable: ItcImagingTableModel = new ItcGenericImagingTableModel(Seq(), Seq(), Seq())
 
   /**
    * Creates a new table model for the current context (instrument) and config sequence.
    * Note that GMOS has a different table model with separate columns for its three CCDs.
    */
-  def tableModel(keys: Seq[ItemKey], seq: ConfigSequence): ItcImagingTableModel =
+  def tableModel(keys: Seq[ItemKey], seq: ConfigSequence): ItcImagingTableModel = {
+    val uniqConfigs = ItcUniqueConfig.imagingConfigs(seq)
+    val results     = uniqConfigs.map(callService)
     Option(owner.getContextInstrument).fold(emptyTable) {
-    _.getType match {
-      case SPComponentType.INSTRUMENT_GMOS        => new ItcGmosImagingTableModel(keys, ItcUniqueConfig.imagingConfigs(seq))
-      case SPComponentType.INSTRUMENT_GMOSSOUTH   => new ItcGmosImagingTableModel(keys, ItcUniqueConfig.imagingConfigs(seq))
-      case _                                      => new ItcGenericImagingTableModel(keys, ItcUniqueConfig.imagingConfigs(seq))
+      _.getType match {
+        case SPComponentType.INSTRUMENT_GMOS      => new ItcGmosImagingTableModel(keys, uniqConfigs, results)
+        case SPComponentType.INSTRUMENT_GMOSSOUTH => new ItcGmosImagingTableModel(keys, uniqConfigs, results)
+        case _                                    => new ItcGenericImagingTableModel(keys, uniqConfigs, results)
+      }
     }
   }
 }
@@ -77,7 +124,7 @@ class ItcImagingTable(val owner: EdIteratorFolder) extends ItcTable {
 class ItcSpectroscopyTable(val owner: EdIteratorFolder) extends ItcTable {
 
   /** Creates a new table model for the current context and config sequence. */
-  def tableModel(keys: Seq[ItemKey], seq: ConfigSequence) = new ItcGenericSpectroscopyTableModel(keys, ItcUniqueConfig.spectroscopyConfigs(seq))
+  def tableModel(keys: Seq[ItemKey], seq: ConfigSequence) = new ItcGenericSpectroscopyTableModel(keys, ItcUniqueConfig.spectroscopyConfigs(seq), Seq())
 
 }
 

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcTableModel.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcTableModel.scala
@@ -7,7 +7,9 @@ import edu.gemini.shared.util.StringUtil
 import edu.gemini.spModel.config2.ItemKey
 
 import scala.concurrent.Future
-import scala.util.Failure
+import scala.util.{Success, Failure}
+
+import scalaz.Scalaz._
 
 /** Columns in the table are defined by their header label and a function on the unique config of the row. */
 case class Column(label: String, value: (ItcUniqueConfig, Future[ItcService.Result]) => Object)
@@ -36,25 +38,26 @@ sealed trait ItcTableModel extends AbstractTableModel {
   val uniqueSteps: Seq[ItcUniqueConfig]
   val res: Seq[Future[ItcService.Result]]
 
-  def getRowCount: Int = uniqueSteps.size
+  override def getRowCount: Int = uniqueSteps.size
 
-  def getColumnCount: Int = headers.size + keys.size + results.size
+  override def getColumnCount: Int = headers.size + keys.size + results.size
 
-  def getKeyAt(col: Int): Option[ItemKey] = col match {
-    case c if c >= headers.size && c < headers.size + keys.size => Some(key(col))
-    case _ => None
-  }
-
-  def getValueAt(row: Int, col: Int): Object = col match {
-    case c if c < headers.size => header(col).value(uniqueSteps(row), res(row))
+  override def getValueAt(row: Int, col: Int): Object = col match {
+    case c if c <  headers.size             => header(col).value(uniqueSteps(row), res(row))
     case c if c >= headers.size + keys.size => result(col).value(uniqueSteps(row), res(row))
-    case c => uniqueSteps(row).config.getItemValue(key(col))
+    case c                                  => uniqueSteps(row).config.getItemValue(key(col))
   }
 
   override def getColumnName(col: Int): String = col match {
-    case c if c < headers.size => header(col).label
+    case c if c <  headers.size             => header(col).label
     case c if c >= headers.size + keys.size => result(col).label
-    case c => StringUtil.toDisplayName(key(col).getName)
+    case c                                  => StringUtil.toDisplayName(key(col).getName)
+  }
+
+  // Gets the ItemKey of a column (if any), this is used by the table to color code the columns.
+  def getKeyAt(col: Int): Option[ItemKey] = col match {
+    case c if c >= headers.size && c < headers.size + keys.size => Some(key(col))
+    case _                                                      => None
   }
 
   // Translate overall column index into the corresponding header, column or key value.
@@ -64,67 +67,78 @@ sealed trait ItcTableModel extends AbstractTableModel {
 
   private def result(col: Int) = results(col - headers.size - keys.size)
 
-  // Gets the imaging result from the service result future (if present)
-  protected def imagingResult(f: Future[ItcService.Result]): Option[ItcImagingResult] =
+  // Gets the result from the service result future (if present)
+  protected def imagingCalcResult(f: Future[ItcService.Result]): Option[ItcResult] =
+    for {
+      futureResult  <- f.value                // unwrap future
+      serviceResult <- futureResult.toOption  // unwrap try
+      calcResult    <- serviceResult.toOption // unwrap validation
+    } yield calcResult
+
+  // TODO: display errors/validation messages in an appropriate way in the UI, for now also print them to console
+  protected def messages(f: Future[ItcService.Result]): String =
+    f.value.fold("Calculating...") {
+      case Failure(t) => t <| (_.printStackTrace()) |> (_.getMessage)  // "Look mummy, there's a spaceship up in the sky!"
+      case Success(s) => s match {
+        case scalaz.Failure(errs) => errs.mkString(", ") <| System.out.println
+        case scalaz.Success(_)    => "OK"
+      }
+    }
+}
+
+
+/** Generic ITC imaging tables model. */
+sealed trait ItcImagingTableModel extends ItcTableModel {
+
+  // Gets the imaging result from the service result future (if present).
+  // Note that in most cases (except for GMOS) there is only one CCD in the result, but for GMOS there can be
+  // 1 or 3 CCDs depending on the selected CCD manufacturer.
+  protected def imagingResult(f: Future[ItcService.Result], n: Int = 0): Option[ItcImagingResult] =
     imagingCalcResult(f).flatMap { r =>
-      r.ccd match {
+      // For GMOS ITC returns 1 or 3 different CCD results depending on the manufacturer, the simplest way to deal
+      // with this is by just using n % #CCDs here, which means that if there is only one result it is repeated three
+      // times, and if there are 3 results, they are shown individually as expected. All instruments other than GMOS
+      // use this method with ccd index = 0.
+      r.ccds(n % r.ccds.length) match {
         case img: ItcImagingResult => Some(img)
         case _                     => None
       }
     }
 
-  // Gets the result from the service result future (if present)
-  protected def imagingCalcResult(f: Future[ItcService.Result]): Option[ItcResult] =
-    for {
-      futureResult  <- f.value                // unwrap future
-      serviceResult <- futureResult.toOption  // unwrap try (as option)
-      calcResult    <- serviceResult.toOption // unwrap validation (as option)
-    } yield calcResult
+  protected def peakPixelFlux(f: Future[ItcService.Result], n: Int = 0) = prettyPrint(f, n, r => r.peakPixelFlux)
 
-  // TODO: display errors/validation messages in an appropriate way in the UI, for now just print them
-  protected def messages(f: Future[ItcService.Result]): String =
-    if (!f.isCompleted) "Calculating..."
-    else if (f.value.get.isFailure) {
-      val msg = "Error Service Call: " + (f.value.get match { case Failure(t) => t.printStackTrace(); t.getMessage})
-      System.out.println(msg)
-      msg
-    }
-    else if (f.value.get.get.isFailure) {
-      f.value.get.get match {case scalaz.Failure(s) => s.foreach(msg => System.out.println("Validation failed: " + msg))}
-      "Error Validation"
-    }
-    else "OK"
+  protected def singleSNRatio(f: Future[ItcService.Result], n: Int = 0) = prettyPrint(f, n, r => r.singleSNRatio)
+
+  protected def totalSNRatio (f: Future[ItcService.Result], n: Int = 0) = prettyPrint(f, n, r => r.totalSNRatio)
+
+  private def prettyPrint(f: Future[ItcService.Result], n: Int, v: ItcImagingResult => Double) =
+    imagingResult(f, n).fold("")(x => f"${v(x)}%.2f")
+
 }
-
-
-/** Generic ITC imaging tables model. */
-sealed trait ItcImagingTableModel extends ItcTableModel
 
 class ItcGenericImagingTableModel(val keys: Seq[ItemKey], val uniqueSteps: Seq[ItcUniqueConfig], val res: Seq[Future[ItcService.Result]]) extends ItcImagingTableModel {
   val headers = ItcTableModel.headers
   val results = Seq(
-    Column("PPF",             (c, r) => imagingResult(r).fold("")(_.peakPixelFlux.toString)),
-    Column("S/N Single",      (c, r) => imagingResult(r).fold("")(_.singleSNRatio.toString)),
-    Column("S/N Total",       (c, r) => imagingResult(r).fold("")(_.totalSNRatio.toString)),
+    Column("PPF",             (c, r) => peakPixelFlux(r)),
+    Column("S/N Single",      (c, r) => singleSNRatio(r)),
+    Column("S/N Total",       (c, r) => totalSNRatio (r)),
     Column("Messages",        (c, r) => messages(r))
   )
-
-
 }
 
 /** GMOS specific ITC imaging table model. */
 class ItcGmosImagingTableModel(val keys: Seq[ItemKey], val uniqueSteps: Seq[ItcUniqueConfig], val res: Seq[Future[ItcService.Result]]) extends ItcImagingTableModel {
   val headers = ItcTableModel.headers
   val results = Seq(
-    Column("CCD1 PPF",        (c, r) => imagingResult(r).fold("")(x => f"${x.peakPixelFlux}%.2f")),
-    Column("CCD1 S/N Single", (c, r) => imagingResult(r).fold("")(x => f"${x.singleSNRatio}%.2f")),
-    Column("CCD1 S/N Total",  (c, r) => imagingResult(r).fold("")(x => f"${x.totalSNRatio}%.2f")),
-    Column("CCD2 PPF",        (c, r) => ""),
-    Column("CCD2 S/N Single", (c, r) => ""),
-    Column("CCD2 S/N Total",  (c, r) => ""),
-    Column("CCD3 PPF",        (c, r) => ""),
-    Column("CCD3 S/N Single", (c, r) => ""),
-    Column("CCD3 S/N Total",  (c, r) => ""),
+    Column("CCD1 PPF",        (c, r) => peakPixelFlux(r, 0)),
+    Column("CCD1 S/N Single", (c, r) => singleSNRatio(r, 0)),
+    Column("CCD1 S/N Total",  (c, r) => totalSNRatio (r, 0)),
+    Column("CCD2 PPF",        (c, r) => peakPixelFlux(r, 1)),
+    Column("CCD2 S/N Single", (c, r) => singleSNRatio(r, 1)),
+    Column("CCD2 S/N Total",  (c, r) => totalSNRatio (r, 1)),
+    Column("CCD3 PPF",        (c, r) => peakPixelFlux(r, 2)),
+    Column("CCD3 S/N Single", (c, r) => singleSNRatio(r, 2)),
+    Column("CCD3 S/N Total",  (c, r) => totalSNRatio (r, 2)),
     Column("Messages",        (c, r) => messages(r))
   )
 }

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcTableModel.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcTableModel.scala
@@ -2,19 +2,23 @@ package jsky.app.ot.editor.seq
 
 import javax.swing.table.AbstractTableModel
 
+import edu.gemini.itc.shared.{ItcImagingResult, ItcResult, ItcService}
 import edu.gemini.shared.util.StringUtil
 import edu.gemini.spModel.config2.ItemKey
 
+import scala.concurrent.Future
+import scala.util.Failure
+
 /** Columns in the table are defined by their header label and a function on the unique config of the row. */
-case class Column(label: String, value: ItcUniqueConfig => Object)
+case class Column(label: String, value: (ItcUniqueConfig, Future[ItcService.Result]) => Object)
 
 object ItcTableModel {
   /** Defines a set of header columns for all tables. */
   val headers = Seq(
-    Column("Data Labels",     c => c.labels),
-    Column("Images",          c => new java.lang.Integer(c.count)),             // must be an object for JTable
-    Column("Exposure Time",   c => new java.lang.Double(c.singleExposureTime)), // must be an object for JTable
-    Column("Total Exp. Time", c => new java.lang.Double(c.totalExposureTime))   // must be an object for JTable
+    Column("Data Labels",     (c, r) => c.labels),
+    Column("Images",          (c, r) => new java.lang.Integer(c.count)),             // must be an object for JTable
+    Column("Exposure Time",   (c, r) => new java.lang.Double(c.singleExposureTime)), // must be an object for JTable
+    Column("Total Exp. Time", (c, r) => new java.lang.Double(c.totalExposureTime))   // must be an object for JTable
   )
 }
 
@@ -26,9 +30,11 @@ object ItcTableModel {
 sealed trait ItcTableModel extends AbstractTableModel {
 
   val headers: Seq[Column]
-  val keys:    Seq[ItemKey]
+  val keys: Seq[ItemKey]
   val results: Seq[Column]
+
   val uniqueSteps: Seq[ItcUniqueConfig]
+  val res: Seq[Future[ItcService.Result]]
 
   def getRowCount: Int = uniqueSteps.size
 
@@ -36,55 +42,90 @@ sealed trait ItcTableModel extends AbstractTableModel {
 
   def getKeyAt(col: Int): Option[ItemKey] = col match {
     case c if c >= headers.size && c < headers.size + keys.size => Some(key(col))
-    case _                                                      => None
+    case _ => None
   }
 
   def getValueAt(row: Int, col: Int): Object = col match {
-    case c if c <  headers.size               => header(col).value(uniqueSteps(row))
-    case c if c >= headers.size + keys.size   => result(col).value(uniqueSteps(row))
-    case c                                    => uniqueSteps(row).config.getItemValue(key(col))
+    case c if c < headers.size => header(col).value(uniqueSteps(row), res(row))
+    case c if c >= headers.size + keys.size => result(col).value(uniqueSteps(row), res(row))
+    case c => uniqueSteps(row).config.getItemValue(key(col))
   }
 
   override def getColumnName(col: Int): String = col match {
-    case c if c <  headers.size               => header(col).label
-    case c if c >= headers.size + keys.size   => result(col).label
-    case c                                    => StringUtil.toDisplayName(key(col).getName)
+    case c if c < headers.size => header(col).label
+    case c if c >= headers.size + keys.size => result(col).label
+    case c => StringUtil.toDisplayName(key(col).getName)
   }
 
   // Translate overall column index into the corresponding header, column or key value.
   private def header(col: Int) = headers(col)
-  private def key   (col: Int) = keys   (col - headers.size)
+
+  private def key(col: Int) = keys(col - headers.size)
+
   private def result(col: Int) = results(col - headers.size - keys.size)
 
- }
+  // Gets the imaging result from the service result future (if present)
+  protected def imagingResult(f: Future[ItcService.Result]): Option[ItcImagingResult] =
+    imagingCalcResult(f).flatMap { r =>
+      r.ccd match {
+        case img: ItcImagingResult => Some(img)
+        case _                     => None
+      }
+    }
+
+  // Gets the result from the service result future (if present)
+  protected def imagingCalcResult(f: Future[ItcService.Result]): Option[ItcResult] =
+    for {
+      futureResult  <- f.value                // unwrap future
+      serviceResult <- futureResult.toOption  // unwrap try (as option)
+      calcResult    <- serviceResult.toOption // unwrap validation (as option)
+    } yield calcResult
+
+  // TODO: display errors/validation messages in an appropriate way in the UI, for now just print them
+  protected def messages(f: Future[ItcService.Result]): String =
+    if (!f.isCompleted) "Calculating..."
+    else if (f.value.get.isFailure) {
+      val msg = "Error Service Call: " + (f.value.get match { case Failure(t) => t.printStackTrace(); t.getMessage})
+      System.out.println(msg)
+      msg
+    }
+    else if (f.value.get.get.isFailure) {
+      f.value.get.get match {case scalaz.Failure(s) => s.foreach(msg => System.out.println("Validation failed: " + msg))}
+      "Error Validation"
+    }
+    else "OK"
+}
+
 
 /** Generic ITC imaging tables model. */
 sealed trait ItcImagingTableModel extends ItcTableModel
 
-class ItcGenericImagingTableModel(val keys: Seq[ItemKey], val uniqueSteps: Seq[ItcUniqueConfig]) extends ItcImagingTableModel {
+class ItcGenericImagingTableModel(val keys: Seq[ItemKey], val uniqueSteps: Seq[ItcUniqueConfig], val res: Seq[Future[ItcService.Result]]) extends ItcImagingTableModel {
   val headers = ItcTableModel.headers
   val results = Seq(
-    Column("PPF",             c => ""),
-    Column("S/N Single",      c => ""),
-    Column("S/N Total",       c => ""),
-    Column("Messages",        c => "OK")
+    Column("PPF",             (c, r) => imagingResult(r).fold("")(_.peakPixelFlux.toString)),
+    Column("S/N Single",      (c, r) => imagingResult(r).fold("")(_.singleSNRatio.toString)),
+    Column("S/N Total",       (c, r) => imagingResult(r).fold("")(_.totalSNRatio.toString)),
+    Column("Messages",        (c, r) => messages(r))
   )
+
+
 }
 
 /** GMOS specific ITC imaging table model. */
-class ItcGmosImagingTableModel(val keys: Seq[ItemKey], val uniqueSteps: Seq[ItcUniqueConfig]) extends ItcImagingTableModel {
+class ItcGmosImagingTableModel(val keys: Seq[ItemKey], val uniqueSteps: Seq[ItcUniqueConfig], val res: Seq[Future[ItcService.Result]]) extends ItcImagingTableModel {
   val headers = ItcTableModel.headers
   val results = Seq(
-    Column("CCD1 PPF",        c => ""),
-    Column("CCD1 S/N Single", c => ""),
-    Column("CCD1 S/N Total",  c => ""),
-    Column("CCD2 PPF",        c => ""),
-    Column("CCD2 S/N Single", c => ""),
-    Column("CCD2 S/N Total",  c => ""),
-    Column("CCD3 PPF",        c => ""),
-    Column("CCD3 S/N Single", c => ""),
-    Column("CCD3 S/N Total",  c => ""),
-    Column("Messages",        c => "OK")
+    Column("CCD1 PPF",        (c, r) => imagingResult(r).fold("")(x => f"${x.peakPixelFlux}%.2f")),
+    Column("CCD1 S/N Single", (c, r) => imagingResult(r).fold("")(x => f"${x.singleSNRatio}%.2f")),
+    Column("CCD1 S/N Total",  (c, r) => imagingResult(r).fold("")(x => f"${x.totalSNRatio}%.2f")),
+    Column("CCD2 PPF",        (c, r) => ""),
+    Column("CCD2 S/N Single", (c, r) => ""),
+    Column("CCD2 S/N Total",  (c, r) => ""),
+    Column("CCD3 PPF",        (c, r) => ""),
+    Column("CCD3 S/N Single", (c, r) => ""),
+    Column("CCD3 S/N Total",  (c, r) => ""),
+    Column("Messages",        (c, r) => messages(r))
   )
 }
 
@@ -92,10 +133,10 @@ class ItcGmosImagingTableModel(val keys: Seq[ItemKey], val uniqueSteps: Seq[ItcU
 /** Generic ITC spectroscopy table model. */
 sealed trait ItcSpectroscopyTableModel extends ItcTableModel
 
-class ItcGenericSpectroscopyTableModel(val keys: Seq[ItemKey], val uniqueSteps: Seq[ItcUniqueConfig]) extends ItcSpectroscopyTableModel {
+class ItcGenericSpectroscopyTableModel(val keys: Seq[ItemKey], val uniqueSteps: Seq[ItcUniqueConfig], val res: Seq[Future[ItcService.Result]]) extends ItcSpectroscopyTableModel {
   val headers = ItcTableModel.headers
   val results = Seq(
-    Column("Messages",        c => "OK")
+    Column("Messages",        (c, r) => messages(r))
   )
 }
 

--- a/project/OcsApp.scala
+++ b/project/OcsApp.scala
@@ -64,7 +64,8 @@ trait OcsApp { this: OcsBundle =>
     bundle_edu_gemini_wdba_xmlrpc_server,
     bundle_edu_gemini_obslog,
     bundle_edu_gemini_services_server,
-    bundle_edu_gemini_smartgcal_servlet
+    bundle_edu_gemini_smartgcal_servlet,
+    bundle_edu_gemini_itc
   )
 
   lazy val app_weather = project.in(file("app/weather")).dependsOn(

--- a/project/OcsBundle.scala
+++ b/project/OcsBundle.scala
@@ -59,9 +59,11 @@ trait OcsBundle {
 
   lazy val bundle_edu_gemini_itc_shared = 
     project.in(file("bundle/edu.gemini.itc.shared")).dependsOn(
-      bundle_edu_gemini_util_osgi,
+      bundle_edu_gemini_pot,
       bundle_edu_gemini_shared_util,
-      bundle_edu_gemini_pot
+      bundle_edu_gemini_util_osgi,
+      bundle_edu_gemini_util_security,
+      bundle_edu_gemini_util_trpc
     )
 
   lazy val bundle_edu_gemini_itc = 
@@ -540,6 +542,7 @@ trait OcsBundle {
       bundle_edu_gemini_shared_skyobject,
       bundle_edu_gemini_ags,
       bundle_edu_gemini_horizons_api,
+      bundle_edu_gemini_itc_shared,
       bundle_edu_gemini_p2checker,
       bundle_edu_gemini_phase2_core,
       bundle_edu_gemini_pot,


### PR DESCRIPTION
This PR brings a working end-to-end implementation of the ITC service without any bells and whistles. Improvements like client-side caching of calculation results etc. are planned for upcoming PRs.

Unfortunately this PR is a bit biggish because I had to rename/refactor quite a few things to get the TRCP service to work which rippled through to a lot of the files.

Main relevant changes are the inclusion of the ITC bundles into the spdb application and additions to the `ItcTable` and `ItcTableModel` classes to perform service calls and handle the results. Future refinements will probably see some of the ITC services related tasks (like creation of input parameter obejcts) being extracted to some utility classes.

Here it would also be nice to know if there is a way we can already anticipate the usage of ITC in PIT? However since PIT uses its own model I am afraid that the translation of instrument configurations into ITC parameter objects would have to be entirely PIT specific(?).

I also have two questions:
- Do we want to set the Serial Version UIDs for service objects manually?
- Is it correct to use the peer obtained by `ObservingPeer` for the service calls?
